### PR TITLE
fix import url job specs

### DIFF
--- a/curation_concerns-models/app/jobs/import_url_job.rb
+++ b/curation_concerns-models/app/jobs/import_url_job.rb
@@ -15,11 +15,17 @@ class ImportUrlJob < ActiveFedoraIdBasedJob
       path, mime_type = copy_remote_file(generic_file.import_url, f)
       # attach downloaded file to generic file stubbed out
       if CurationConcerns::GenericFileActor.new(generic_file, user).create_content(f, path, mime_type)
-        # add message to user for downloaded file
-        message = "The file (#{generic_file.label}) was successfully imported."
-        job_user.send_message(user, message, 'File Import')
+
+        # send message to user on download success
+        if CurationConcerns.config.respond_to?(:after_import_url_success)
+          CurationConcerns.config.after_import_url_success.call(generic_file)
+        end
       else
-        job_user.send_message(user, generic_file.errors.full_messages.join(', '), 'File Import Error')
+
+        # send message to user on download failure
+        if CurationConcerns.config.respond_to?(:after_import_url_failure)
+          CurationConcerns.config.after_import_url_failure.call(generic_file)
+        end
       end
     end
   end

--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ImportUrlJob do
   let(:user) { FactoryGirl.find_or_create(:jill) }
 
-  let(:file_path) { '/world.png' }
+  let(:file_path) {  fixture_path + '/world.png' }
   let(:file_hash)  {'/673467823498723948237462429793840923582'}
 
   let(:generic_file) do
@@ -18,7 +18,7 @@ describe ImportUrlJob do
     double('response').tap do |http_res|
       allow(http_res).to receive(:start).and_yield
       allow(http_res).to receive(:content_type).and_return('image/png')
-      allow(http_res).to receive(:read_body).and_yield(File.open(File.expand_path('../../fixtures/world.png', __FILE__)).read)
+      allow(http_res).to receive(:read_body).and_yield(File.open(File.expand_path(file_path, __FILE__)).read)
     end
   end
 
@@ -28,40 +28,18 @@ describe ImportUrlJob do
     expect(generic_file.original_file).to be_nil
   end
 
-  ### TODO - Needs Refactoring after Sufia is Broken up
-  # context "after running the job" do
-  #   before do
-  #     s1 = double('content deposit event')
-  #     allow(ContentDepositEventJob).to receive(:new).with(generic_file.id, 'jilluser@example.com').and_return(s1).once
-  #     expect(CurationConcerns.queue).to receive(:push).with(s1).once
-  #
-  #     s2 = double('characterize')
-  #     allow(CharacterizeJob).to receive(:new).with(generic_file.id).and_return(s2)
-  #     expect(CurationConcerns.queue).to receive(:push).with(s2).once
-  #
-  #     expect(CurationConcerns::GenericFileActor).to receive(:virus_check).and_return(false)
-  #   end
-  #
-  #   xit "should create a content datastream" do
-  #     expect_any_instance_of(Net::HTTP).to receive(:request_get).with(file_hash).and_yield(mock_response)
-  #     job.run
-  #     expect(generic_file.reload.content.size).to eq 4218
-  #     expect(user.mailbox.inbox.first.last_message.body).to eq("The file (#{file_path}) was successfully imported.")
-  #   end
-  # end
-  #
-  # context "when the file has a virus" do
-  #   before do
-  #     s1 = double('content deposit event')
-  #     allow(ContentDepositEventJob).to receive(:new).with(generic_file.id, 'jilluser@example.com').never
-  #
-  #     s2 = double('characterize')
-  #     allow(CharacterizeJob).to receive(:new).with(generic_file.id).never
-  #   end
-  #   xit "should abort if virus check fails" do
-  #     allow(CurationConcerns::GenericFileActor).to receive(:virus_check).and_raise(Sufia::VirusFoundError.new('A virus was found'))
-  #     job.run
-  #     expect(user.mailbox.inbox.first.subject).to eq("File Import Error")
-  #   end
-  # end
+  context "after running the job" do
+    before do  
+      s1 = double('characterize')
+      allow(CharacterizeJob).to receive(:new).with(generic_file.id).and_return(s1)
+      expect(CurationConcerns.queue).to receive(:push).with(s1).once
+      expect(CurationConcerns::VirusDetectionService).to receive(:run).and_return(false)
+    end
+  
+    it "should create a content datastream" do
+      expect_any_instance_of(Net::HTTP).to receive(:request_get).with(file_hash).and_yield(mock_response)
+      job.run
+      expect(generic_file.reload.original_file.size).to eq 4218
+    end
+  end
 end


### PR DESCRIPTION
Fixes import url job spec and refactors user messaging out of import url job. Please take a look at the virus check section (especially line [49](https://github.com/projecthydra-labs/curation_concerns/blob/cb60438ca55b52bbdcde922b04dd9662e534f7db/spec/jobs/import_url_job_spec.rb#L49)). I think what is happening is that build_original_file clobbers the existing file (from the previous test) so that you start fresh when the job is run again. There's probably a more sophisticated way of doing this, but it passes as it is.