### PR TITLE
remove mailboxer from user model

### DIFF
--- a/curation_concerns-models/app/models/concerns/curation_concerns/user.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/user.rb
@@ -4,7 +4,6 @@ module CurationConcerns::User
   # Copied piecemeal from the pcdm branch of sufia-models. More may yet be necessary.
 
   included do
-    # include Mailboxer::Models::Messageable
     # Connects this user object to Blacklight's Bookmarks and Folders.
     include Blacklight::User
     include Hydra::User
@@ -41,11 +40,6 @@ module CurationConcerns::User
     user_key.gsub(/\./, '-dot-')
   end
 
-  # method needed for messaging
-  # def mailboxer_email(obj=nil)
-  #   nil
-  # end
-
   # The basic groups method, override or will fallback to S ufia::Ldap::User
   # def groups
   #   @groups ||= self.group_list ? self.group_list.split(";?;") : []
@@ -63,26 +57,6 @@ module CurationConcerns::User
     def current=(user)
       Thread.current[:user] = user
     end
-
-    # Override this method if you aren't using email/password
-    def audituser
-      User.find_by_user_key(audituser_key) || User.create!(Devise.authentication_keys.first => audituser_key, password: Devise.friendly_token[0,20])
-    end
-
-    # Override this method if you aren't using email as the userkey
-    # def audituser_key
-    #   'audituser@example.com'
-    # end
-
-    # Override this method if you aren't using email/password
-    # def batchuser
-    #   User.find_by_user_key(batchuser_key) || User.create!(Devise.authentication_keys.first => batchuser_key, password: Devise.friendly_token[0,20])
-    # end
-
-    # Override this method if you aren't using email as the userkey
-    # def batchuser_key
-    #   'batchuser@example.com'
-    # end
 
     # def from_url_component(component)
     #   User.find_by_user_key(component.gsub(/-dot-/, '.'))


### PR DESCRIPTION
Removes mailboxer user messaging related code from user.rb. See #62 and projecthydra-labs/sufia-core/issues/6.