### PR TITLE
Faster indexing not extending PCDM::ObjectIndexer

### DIFF
--- a/curation_concerns-models/app/services/curation_concerns/generic_file_indexing_service.rb
+++ b/curation_concerns-models/app/services/curation_concerns/generic_file_indexing_service.rb
@@ -1,5 +1,5 @@
 module CurationConcerns
-  class GenericFileIndexingService < Hydra::PCDM::ObjectIndexer
+  class GenericFileIndexingService < ActiveFedora::IndexingService
     def generate_solr_document
       super.tap do |solr_doc|
         solr_doc[Solrizer.solr_name('label')] = object.label

--- a/curation_concerns-models/app/services/curation_concerns/generic_work_indexing_service.rb
+++ b/curation_concerns-models/app/services/curation_concerns/generic_work_indexing_service.rb
@@ -1,10 +1,13 @@
 module CurationConcerns
-  class GenericWorkIndexingService < Hydra::PCDM::ObjectIndexer
+  class GenericWorkIndexingService < ActiveFedora::IndexingService
 
     def generate_solr_document
-      # leaving this in place since I know we will want to add generic files into the work's solr index
       super.tap do |solr_doc|
-        solr_doc[Solrizer.solr_name('generic_files')] = object.generic_file_ids
+        # We know that all the members of GenericWorks are GenericFiles so we can use
+        # member_ids which requires fewer Fedora API calls than generic_file_ids.
+        # generic_file_ids requires loading all the members from Fedora but member_ids
+        # looks just at solr
+        solr_doc[Solrizer.solr_name('generic_file_ids', :symbol)] = object.member_ids
       end
     end
 

--- a/spec/models/curation_concerns/generic_file_spec.rb
+++ b/spec/models/curation_concerns/generic_file_spec.rb
@@ -378,8 +378,6 @@ describe CurationConcerns::GenericFile do
     end
   end
 
-
-
   describe "to_solr" do
     before do
       subject.title = ['One Flew Over the Cuckoo\'s Nest']

--- a/spec/services/generic_work_indexing_service_spec.rb
+++ b/spec/services/generic_work_indexing_service_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe CurationConcerns::GenericWorkIndexingService do
+  let(:generic_work) { GenericWork.create { |gf| gf.apply_depositor_metadata('jcoyne') } }
+  let(:service) { described_class.new(generic_work) }
+
+  let(:generic_file) { GenericFile.new(id: '123') { |gf| gf.apply_depositor_metadata('jcoyne') } }
+  subject { service.generate_solr_document }
+
+  context "with generic_files" do
+    before do
+      generic_work.members << generic_file
+    end
+
+    it "indexes files" do
+      expect(subject['generic_file_ids_ssim']).to eq ['123']
+    end
+  end
+end


### PR DESCRIPTION
Hydra::PCDM::ObjectIndexer loads all the members in an aggregation and
sorts them by type. This is particularly slow. CurationConcerns makes
the assumption that all children of GenericWorks are GenericFiles, thus
we can take a shortcut, query solr and skip loading the whole
aggregation from Fedora.

Fixes #84