### PR TITLE
fixes signature for audit log messaging

### DIFF
--- a/curation_concerns-models/app/jobs/audit_job.rb
+++ b/curation_concerns-models/app/jobs/audit_job.rb
@@ -22,9 +22,9 @@ class AuditJob < ActiveFedoraIdBasedJob
     fixity_ok = (log.pass == 1)
     unless fixity_ok
       if CurationConcerns.config.respond_to?(:after_audit_failure)
-        file_title = generic_file.title.first
-        message = "The audit run at #{log.created_at} for #{file_title} (#{uri}) failed."
-        CurationConcerns.config.after_audit_failure.call(generic_file, message)
+        login = generic_file.depositor
+        user = User.find_by_user_key(login)
+        CurationConcerns.config.after_audit_failure.call(generic_file, user, log.created_at)
       end
     end
     fixity_ok


### PR DESCRIPTION
User messaging callback requires user and log date to be passed in as well as generic_file. The callback code lives in sufia-core, not in curation_concerns. Curation_concerns triggers the callback but doesn't doesn't implement it. The code can be found here: projecthydra-labs/sufia-core#39. 