### PR TITLE
fixes signature for import url messaging

### DIFF
--- a/curation_concerns-models/app/jobs/import_url_job.rb
+++ b/curation_concerns-models/app/jobs/import_url_job.rb
@@ -18,13 +18,13 @@ class ImportUrlJob < ActiveFedoraIdBasedJob
 
         # send message to user on download success
         if CurationConcerns.config.respond_to?(:after_import_url_success)
-          CurationConcerns.config.after_import_url_success.call(generic_file)
+          CurationConcerns.config.after_import_url_success.call(generic_file, user)
         end
       else
 
         # send message to user on download failure
         if CurationConcerns.config.respond_to?(:after_import_url_failure)
-          CurationConcerns.config.after_import_url_failure.call(generic_file)
+          CurationConcerns.config.after_import_url_failure.call(generic_file, user)
         end
       end
     end


### PR DESCRIPTION
User messaging callback requires user to be passed in as well as generic_file. The callback code lives in sufia-core, not in curation_concerns. Curation_concerns triggers the callback but doesn't doesn't implement it. The code can be found here: projecthydra-labs/sufia-core#39. 