### PR TITLE
restores collection-related view partials and helpers

### DIFF
--- a/app/helpers/curation_concerns/collections_helper.rb
+++ b/app/helpers/curation_concerns/collections_helper.rb
@@ -1,4 +1,12 @@
 module CurationConcerns::CollectionsHelper
+  def has_collection_search_parameters?
+    params[:cq].present?
+  end
+
+  def collection_modal_id(collectible)
+    "#{collectible.to_param.gsub(/:/, '-')}-modal"
+  end
+
   def link_to_select_collection(collectible, opts={})
     html_class = opts[:class]
     link_to '#', data: { toggle: "modal", target: '#' + collection_modal_id(collectible) },
@@ -15,15 +23,41 @@ module CurationConcerns::CollectionsHelper
     end
   end
 
+  def icon(type)
+    content_tag :span, '', class: "glyphicon glyphicon-#{type}"
+  end
+
+  def collection_options_for_select(exclude_item = nil)
+    options_for_select(available_collections(exclude_item))
+  end
+
   private
-
-    def icon(type)
-      content_tag :span, '', class: "glyphicon glyphicon-#{type}"
+    # return a list of collections for the current user with the exception of the passed in collection
+    def available_collections(exclude_item)
+      if exclude_item
+        collection_options.reject {|n| n.last == exclude_item.id}
+      else
+        collection_options
+      end
     end
 
-    def collection_modal_id(collectible)
-      "#{collectible.to_param.gsub(/:/, '-')}-modal"
+
+    def collection_options
+      @collection_options ||= current_users_collections
     end
 
+    # Defaults to returning a list of all collections.
+    # If you have implement User.collections, the results of that will be used.
+    def current_users_collections
+      if current_user.respond_to?(:collections)
+        current_user.collections.map { |c| [c.title.join(', '), c.id] }
+      else
+        query = ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: Collection.to_class_uri)
+        ActiveFedora::SolrService.query(query, fl: 'title_tesim id',
+                                        rows: 1000).map do |r|
+          [r['title_tesim'].join(', '), r['id']]
+        end.sort { |a, b| a.first <=> b.first }
+      end
+    end
 
 end

--- a/app/helpers/curation_concerns/url_helper.rb
+++ b/app/helpers/curation_concerns/url_helper.rb
@@ -6,7 +6,7 @@ module CurationConcerns
     def url_for_document doc, options = {}
       if Hydra::Works.generic_file?(doc)
         main_app.curation_concerns_generic_file_path(doc)
-      elsif Hydra::Works.generic_file?(doc)
+      elsif doc.collection?
         doc
       else
         polymorphic_path([main_app, :curation_concerns, doc])

--- a/app/views/catalog/_action_menu_partials/_collection.html.erb
+++ b/app/views/catalog/_action_menu_partials/_collection.html.erb
@@ -1,0 +1,27 @@
+<div class="btn-group">
+  <button class="btn btn-default btn-small dropdown-toggle" data-toggle="dropdown" href="#">Select an action <span class="caret"></span></button>
+  <ul class="dropdown-menu">
+    <% if can? :edit, document %>
+      <li>
+        <%= link_to [collections, :edit, document], class: 'itemicon itemedit' do %><i class="glyphicon glyphicon-pencil"></i> Edit <%= document.human_readable_type %>
+        <% end %>
+      </li>
+      <li>
+        <% if @collection # We're on the view page for @collection. -%>
+          <%= button_for_remove_from_collection(document) %>
+        <% else %>
+          <%= link_to [collections, document], class: 'itemicon itemtrash', title: 'Delete Collection', method: :delete, data: {
+                          confirm: "Deleting a collection from #{t('sufia.product_name')} is permanent. Click OK to delete this collection from #{t('sufia.product_name')}, or Cancel to cancel this operation" } do %>
+                          <i class="glyphicon glyphicon-trash"></i> Delete <%= document.human_readable_type %>
+          <% end %>
+        <% end %>
+      </li>
+    <% end %>
+    <% if can? :collect, document %>
+      <li>
+        <%= link_to_select_collection document %>
+      </li>
+    <% end %>
+  </ul>
+  <%= render 'collections/add_to_collection_modal', collectible: document if can? :collect, document %>
+</div>

--- a/app/views/collections/_add_to_collection_modal.html.erb
+++ b/app/views/collections/_add_to_collection_modal.html.erb
@@ -1,0 +1,15 @@
+<% modal_id = collection_modal_id(collectible) %>
+<% modal_title_id = "#{modal_id}-title" %>
+
+<div class="modal fade" id="<%= modal_id %>">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 id="<% modal_title_id %>" class="modal-title">Add <%= collectible %> to one of your collections:</h4>
+      </div>
+      <div class="unpadded modal-body">
+        <%= render 'collections/form_to_add_member', collectible: collectible, fieldset_class: 'with-side-padding with-top-padding', select_label_id: modal_title_id %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/collections/_button_remove_from_collection.html.erb
+++ b/app/views/collections/_button_remove_from_collection.html.erb
@@ -1,0 +1,6 @@
+<%#= button_to label, ,  :class=>"btn btn-primary collection-remove", 'data-behavior'=>'hydra-collections-remove', members:"delete", batch_document_ids:[document.id] %>
+
+<%= form_for collection, url:collections.collection_path(collection.id), :method=>:put, as:'collection' do |f| %>
+  <%= single_item_action_remove_form_fields(f,document) %>
+  <%= f.submit label, :class => "btn btn-danger collection-remove" %>
+<% end %>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -1,0 +1,1 @@
+<%= render 'document', document: collection, document_counter: collection_counter %>

--- a/app/views/collections/_form_to_add_member.html.erb
+++ b/app/views/collections/_form_to_add_member.html.erb
@@ -1,0 +1,21 @@
+<% fieldset_class  ||= '' %>
+<% select_label_id ||= '' %>
+
+<%= form_tag collections.collections_path, method: :put do %>
+  <fieldset class="required <%= fieldset_class %>">
+    <%= hidden_field_tag 'collection[members]', 'add' %>
+    <%= hidden_field_tag 'batch_document_ids[]', collectible.id %>
+
+    <div class="form-group collection_id">
+      <div class="controls">
+        <%= select_tag :id, collection_options_for_select(collectible), prompt: 'Make a Selection',
+          class: 'form-control', :'aria-labelledby' => select_label_id %>
+      </div>
+    </div>
+
+  </fieldset>
+  <div class="form-actions with-side-padding with-footroom">
+    <%= submit_tag "Add to collection", class: 'btn btn-primary' %>
+    <%= link_to 'Cancel', root_path, class: 'btn btn-default', data: { dismiss: 'modal' } %>
+  </div>
+<% end %>

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency 'rspec-html-matchers'
+  spec.add_development_dependency 'rspec-activemodel-mocks', '~> 1.0'
   spec.add_development_dependency "capybara"
   spec.add_development_dependency "poltergeist", ">= 1.5.0"
   spec.add_development_dependency "factory_girl"

--- a/spec/helpers/curation_concerns/collections_helper_spec.rb
+++ b/spec/helpers/curation_concerns/collections_helper_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe CurationConcerns::CollectionsHelper do
+
   describe "#link_to_select_collection" do
     let(:collection) { double(id: '123') }
     let(:collectible) { double(id: '456', human_readable_type: 'Generic Work', to_param: '456') }
@@ -31,4 +32,17 @@ describe CurationConcerns::CollectionsHelper do
     end
   end
 
+  describe "#collection_options_for_select" do
+    before do
+      allow(helper).to receive(:current_user).and_return(User.new)
+    end
+    let!(:collection1) { Collection.create!(id: '123', title: 'One') }
+    let!(:collection2) { Collection.create!(id: '456', title: 'Two') }
+    let!(:collection3) { Collection.create!(id: '789', title: 'Thre') }
+    subject { helper.collection_options_for_select(collection2) }
+
+    it "excludes the passed in collection" do
+      expect(subject).to eq "<option value=\"#{collection1.id}\">#{collection1.title}</option>\n<option value=\"#{collection3.id}\">#{collection3.title}</option>"
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'devise'
 
 require 'rspec/its'
 require 'rspec/rails'
+require 'rspec/active_model/mocks'
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
 Capybara.default_wait_time = ENV['TRAVIS'] ? 30 : 15

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'catalog/index.html.erb' do
+  let(:collection) { stub_model(Collection, title: 'collection1', id: 'abc123') }
+  let(:doc) { SolrDocument.new(collection.to_solr) }
+
+  before do
+    view.extend CurationConcerns::CollectionsHelper
+    view.extend CurationConcerns::CatalogHelper
+    allow(view).to receive(:search_action_path).and_return('/catalog')
+    allow(view).to receive(:has_search_parameters?).and_return(true)
+
+
+    allow(view).to receive(:current_users_collections).and_return([])
+    allow(view).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
+    stub_template 'catalog/_search_sidebar.html.erb' => ''
+    stub_template 'catalog/_search_header.html.erb' => ''
+    allow(view).to receive(:render_opensearch_response_metadata).and_return('')
+    allow(view).to receive(:render_grouped_response?).and_return(false)
+    allow(view).to receive(:search_session).and_return({})
+    allow(view).to receive(:current_search_session).and_return(nil)
+    allow(view).to receive(:document_counter_with_offset).and_return(5)
+
+    params[:view] = 'gallery'
+
+    resp = []
+    assign(:response, resp )
+    allow(resp).to receive(:total_pages).and_return(1)
+    allow(resp).to receive(:current_page).and_return(1)
+    allow(resp).to receive(:limit_value).and_return(10)
+    allow(resp).to receive(:empty?).and_return(false)
+
+    # This stubs out the SolrDocument#to_model
+    allow(ActiveFedora::Base).to receive(:load_instance_from_solr).with('abc123', doc).and_return(collection)
+
+    assign(:document_list, [doc])
+  end
+
+  context "when user does not have permissions" do
+    before  { allow(view).to receive(:can?).and_return(false) }
+    it 'appears on page without error' do
+      render
+      expect(rendered).to include(collection.title)
+      page = Capybara::Node::Simple.new(rendered)
+      debugger
+      expect(page).to have_selector("span.glyphicon.glyphicon-th.collection-icon-search")
+    end
+  end
+  context "when user has all the permissions" do
+    before  { allow(view).to receive(:can?).and_return(true) }
+    it 'appears on page without error' do
+      render
+      expect(rendered).to include(collection.title)
+      page = Capybara::Node::Simple.new(rendered)
+      expect(page).to have_selector("span.glyphicon.glyphicon-th.collection-icon-search")
+    end
+  end
+
+
+end


### PR DESCRIPTION
This relates to the work @jpstroop is doing to pull all of the collection behaviors and test coverage from sufia-core

There was no test coverage at all for the partials.  I added sufia-core's spec for the catalog/index view.  That triggers these partials.