### PR TITLE
GenericFileActor.create_metadata assumes work is AF::Base, not ::GenericWork

### DIFF
--- a/curation_concerns-models/app/actors/curation_concerns/generic_file_actor.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/generic_file_actor.rb
@@ -44,7 +44,7 @@ module CurationConcerns
         work.creator = [user.name]
         work.save
       else
-        work = GenericWork.find(work_id)
+        work = ActiveFedora::Base.find(work_id)
         copy_visibility(work, generic_file)
       end
       Hydra::Works::AddGenericFileToGenericWork.call(work, generic_file)


### PR DESCRIPTION
This makes it possible for you to use Work types other than GenericWork

I don't have time to write tests (see  #114), but want to offer this fix before I go.