### PR TITLE
refactor to work with latest hydra-works

### DIFF
--- a/app/controllers/concerns/curation_concerns/generic_files_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/generic_files_controller_behavior.rb
@@ -119,7 +119,7 @@ module CurationConcerns
     def process_file(file)
       update_metadata_from_upload_screen
       actor.create_metadata(params[:batch_id], parent_id, params[:generic_file])
-      if actor.create_content(file, file.original_filename, file.content_type)
+      if actor.create_content(file)
         respond_to do |format|
           format.html {
             if request.xhr?

--- a/app/services/curation_concerns/curation_concern.rb
+++ b/app/services/curation_concerns/curation_concern.rb
@@ -8,7 +8,7 @@ module CurationConcerns
     end
 
     def self.attach_file_to_generic_file(generic_file, user, file_to_attach)
-      CurationConcerns::GenericFileActor.new(generic_file, user).create_content(file_to_attach, file_to_attach.original_filename, file_to_attach.content_type)
+      CurationConcerns::GenericFileActor.new(generic_file, user).create_content(file_to_attach)
     end
   end
 end

--- a/curation_concerns-models/app/actors/curation_concerns/work_actor_behavior.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/work_actor_behavior.rb
@@ -71,10 +71,10 @@ module CurationConcerns::WorkActorBehavior
     #TODO we're passing an ID rather than an object. This means the actor does an unnecessary lookup
     generic_file_actor.create_metadata(curation_concern.id, curation_concern.id)
     generic_file.visibility = visibility
-    generic_file_actor.create_content(file, file.original_filename, file.content_type)
+    generic_file_actor.create_content(file)
     @generic_files ||= []
     @generic_files << generic_file # This is so that other methods like assign_representative can access the generic_files wihtout reloading them from fedora
-    Hydra::Works::AddGenericFileToGenericWork.call(curation_concern, generic_file)
+    curation_concern.generic_files << generic_file
   end
 
   def valid_file?(file_path)

--- a/curation_concerns-models/app/jobs/import_url_job.rb
+++ b/curation_concerns-models/app/jobs/import_url_job.rb
@@ -12,9 +12,9 @@ class ImportUrlJob < ActiveFedoraIdBasedJob
     user = User.find_by_user_key(generic_file.depositor)
 
     Tempfile.open(id.gsub('/', '_')) do |f|
-      path, mime_type = copy_remote_file(generic_file.import_url, f)
+      copy_remote_file(generic_file.import_url, f)
       # attach downloaded file to generic file stubbed out
-      if CurationConcerns::GenericFileActor.new(generic_file, user).create_content(f, path, mime_type)
+      if CurationConcerns::GenericFileActor.new(generic_file, user).create_content(f)
 
         # send message to user on download success
         if CurationConcerns.config.respond_to?(:after_import_url_success)
@@ -47,9 +47,7 @@ class ImportUrlJob < ActiveFedoraIdBasedJob
         end
       end
     end
-
     f.rewind
-    return uri.path, mime_type
   end
 
   def job_user

--- a/curation_concerns-models/app/jobs/ingest_local_file_job.rb
+++ b/curation_concerns-models/app/jobs/ingest_local_file_job.rb
@@ -16,11 +16,12 @@ class IngestLocalFileJob
     user = User.find_by_user_key(user_key)
     raise "Unable to find user for #{user_key}" unless user
     generic_file = GenericFile.find(generic_file_id)
+    generic_file.label ||= filename
     path = File.join(directory, filename)
 
     actor = CurationConcerns::GenericFileActor.new(generic_file, user)
 
-    if actor.create_content(File.open(path), filename, mime_type(filename))
+    if actor.create_content(File.open(path))
       FileUtils.rm(path)
 
       # send message to user on import success

--- a/spec/actors/curation_concerns/generic_file_actor_spec.rb
+++ b/spec/actors/curation_concerns/generic_file_actor_spec.rb
@@ -15,7 +15,7 @@ describe CurationConcerns::GenericFileActor do
     before do
       allow(actor).to receive(:save_characterize_and_record_committer).and_return("true")
       actor.create_metadata(batch_id, work_id)
-      actor.create_content(uploaded_file, 'world.png', 'image/png')
+      actor.create_content(uploaded_file)
     end
     context "when a work_id is provided" do
       let(:work) { FactoryGirl.create(:generic_work) }
@@ -35,7 +35,7 @@ describe CurationConcerns::GenericFileActor do
     end
 
     it "uses the provided mime_type" do
-      actor.create_content(uploaded_file, 'world.png', 'image/png')
+      actor.create_content(uploaded_file)
       expect(generic_file.original_file.mime_type).to eq "image/png"
     end
 
@@ -47,7 +47,7 @@ describe CurationConcerns::GenericFileActor do
       before do
         allow(generic_file).to receive(:label).and_return(short_name)
         allow(CurationConcerns.queue).to receive(:push)
-        actor.create_content(fixture_file_upload(file), long_name, 'image/png')
+        actor.create_content(fixture_file_upload(file))
       end
       subject { generic_file.title }
       it { is_expected.to eql [short_name] }
@@ -65,8 +65,8 @@ describe CurationConcerns::GenericFileActor do
 
       before do
         allow(CurationConcerns.queue).to receive(:push)
-        actor1.create_content(fixture_file_upload(file1), file1, 'image/png')
-        actor2.create_content(fixture_file_upload(file2), file2, 'text/plain')
+        actor1.create_content(fixture_file_upload(file1))
+        actor2.create_content(fixture_file_upload(file2))
       end
 
       it "should have two versions" do
@@ -106,7 +106,7 @@ describe CurationConcerns::GenericFileActor do
     before do
       allow(actor).to receive(:save_characterize_and_record_committer).and_return("true")
       allow(Hydra::Works::UploadFileToGenericFile).to receive(:call)
-      actor.create_content(Tempfile.new(new_file), new_file, 'image/jpg')
+      actor.create_content(Tempfile.new(new_file))
     end
 
     it "will retain the object's original label" do

--- a/spec/actors/curation_concerns/work_actor_spec.rb
+++ b/spec/actors/curation_concerns/work_actor_spec.rb
@@ -99,7 +99,7 @@ describe CurationConcerns::GenericWorkActor do
             expect(curation_concern.date_modified).to eq Date.today
             expect(curation_concern.depositor).to eq user.user_key
             expect(curation_concern.representative).to_not be_nil
-            expect(curation_concern.generic_files.count).to eq 1
+            expect(curation_concern.generic_files.size).to eq 1
             # Sanity test to make sure the file we uploaded is stored and has same permission as parent.
             generic_file = curation_concern.generic_files.first
             file.rewind
@@ -130,7 +130,7 @@ describe CurationConcerns::GenericWorkActor do
             expect(curation_concern.date_modified).to eq Date.today
             expect(curation_concern.depositor).to eq user.user_key
 
-            expect(curation_concern.generic_files.count).to eq 2
+            expect(curation_concern.generic_files.size).to eq 2
             # Sanity test to make sure the file we uploaded is stored and has same permission as parent.
 
             expect(curation_concern).to be_authenticated_only_access

--- a/spec/controllers/curation_concerns/collections_controller_spec.rb
+++ b/spec/controllers/curation_concerns/collections_controller_spec.rb
@@ -7,11 +7,11 @@ describe CollectionsController do
   end
 
   let(:user) { FactoryGirl.create(:user) }
-  let(:asset1) { FactoryGirl.build(:generic_file, title: ["First of the Assets"], user: user) }
-  let(:asset2) { FactoryGirl.build(:generic_file, title: ["Second of the Assets"], user: user, depositor: user.user_key) }
-  let(:asset3) { FactoryGirl.build(:generic_file, title: ["Third of the Assets"]) }
-  let!(:asset4) { FactoryGirl.create(:generic_file, title: ["Fourth of the Assets"], user: user) }
-  let(:bogus_depositor_asset) { FactoryGirl.create(:generic_file, title: ["Bogus Asset"], depositor: 'abc') }
+  let(:asset1) { FactoryGirl.build(:generic_work, title: ["First of the Assets"], user: user) }
+  let(:asset2) { FactoryGirl.build(:generic_work, title: ["Second of the Assets"], user: user, depositor: user.user_key) }
+  let(:asset3) { FactoryGirl.build(:generic_work, title: ["Third of the Assets"]) }
+  let!(:asset4) { FactoryGirl.create(:generic_work, title: ["Fourth of the Assets"], user: user) }
+  let(:bogus_depositor_asset) { FactoryGirl.create(:generic_work, title: ["Bogus Asset"], depositor: 'abc') }
   let(:collection_attrs) { FactoryGirl.attributes_for(:collection, title: "My First Collection ", description: "The Description\r\n\r\nand more") }
   let(:collection) { FactoryGirl.create(:collection, title: "Collection Title", user: user) }
 
@@ -66,7 +66,7 @@ describe CollectionsController do
       doc = asset_results["response"]["docs"].first
       expect(doc["id"]).to eq asset1.id
 
-      afterupdate = GenericFile.find(asset1.id)
+      afterupdate = GenericWork.find(asset1.id)
       expect(doc[Solrizer.solr_name(:collection)]).to eq afterupdate.to_solr[Solrizer.solr_name(:collection)]
     end
 
@@ -95,7 +95,7 @@ describe CollectionsController do
         doc = asset_results["response"]["docs"].first
         expect(doc["id"]).to eq asset2.id
 
-        afterupdate = GenericFile.find(asset2.id)
+        afterupdate = GenericWork.find(asset2.id)
         expect(doc[Solrizer.solr_name(:collection)]).to eq afterupdate.to_solr[Solrizer.solr_name(:collection)]
 
         put :update, id: collection,
@@ -107,7 +107,7 @@ describe CollectionsController do
         doc = asset_results["response"]["docs"].first
         expect(doc["id"]).to eq asset2.id
 
-        afterupdate = GenericFile.find(asset2.id)
+        afterupdate = GenericWork.find(asset2.id)
         expect(doc[Solrizer.solr_name(:collection)]).to be_nil
       end
     end

--- a/spec/controllers/curation_concerns/generic_files_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_files_controller_spec.rb
@@ -99,7 +99,7 @@ describe CurationConcerns::GenericFilesController do
           gf.apply_depositor_metadata(user)
           gf.save!
         end
-        Hydra::Works::AddGenericFileToGenericWork.call(parent, generic_file)
+        parent.generic_files << generic_file
         generic_file
       end
 
@@ -118,7 +118,7 @@ describe CurationConcerns::GenericFilesController do
           gf.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
           gf.save!
         end
-        Hydra::Works::AddGenericFileToGenericWork.call(parent, generic_file)
+        parent.generic_files << generic_file
         generic_file
       end
 
@@ -199,9 +199,9 @@ describe CurationConcerns::GenericFilesController do
         before do
           allow(CurationConcerns.queue).to receive(:push) # don't run characterization jobs
           # Create version 1
-          Hydra::Works::AddFileToGenericFile.call(generic_file, fixture_file_path('small_file.txt'), :original_file)
+          Hydra::Works::AddFileToGenericFile.call(generic_file, File.open(fixture_file_path('small_file.txt')), :original_file)
           # Create version 2
-          Hydra::Works::AddFileToGenericFile.call(generic_file, fixture_file_path('curation_concerns_generic_stub.txt'), :original_file)
+          Hydra::Works::AddFileToGenericFile.call(generic_file, File.open(fixture_file_path('curation_concerns_generic_stub.txt')), :original_file)
         end
 
         it "should be successful" do
@@ -225,7 +225,7 @@ describe CurationConcerns::GenericFilesController do
         gf.read_groups = ['public']
         gf.save!
       end
-      Hydra::Works::AddGenericFileToGenericWork.call(parent, generic_file)
+      parent.generic_files << generic_file
       generic_file
     end
     after do

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -5,7 +5,7 @@ describe DownloadsController do
     let(:user) { FactoryGirl.create(:user) }
     let(:another_user) { FactoryGirl.create(:user) }
     let(:generic_file) {
-      FactoryGirl.create(:file_with_work, user: user, content: fixture_file_path('files/image.png'))
+      FactoryGirl.create(:file_with_work, user: user, content: File.open(fixture_file_path('files/image.png')))
     }
 
     it "raise not_found if the object does not exist" do
@@ -42,7 +42,7 @@ describe DownloadsController do
     end
 
     it 'sends requested file content' do
-      Hydra::Works::AddFileToGenericFile.call(generic_file, fixture_file_path('world.png'), :thumbnail)
+      Hydra::Works::AddFileToGenericFile.call(generic_file, File.open(fixture_file_path('world.png')), :thumbnail)
       sign_in user
       get :show, id: generic_file.to_param, file: 'thumbnail'
       expect(response.body).to eq generic_file.thumbnail.content

--- a/spec/controllers/embargoes_controller_spec.rb
+++ b/spec/controllers/embargoes_controller_spec.rb
@@ -85,7 +85,7 @@ describe EmbargoesController do
       let(:a_file) { FactoryGirl.create(:generic_file, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
       let(:release_date) { Date.today+2 }
       before do
-        Hydra::Works::AddGenericFileToGenericWork.call(a_work, a_file)
+        a_work.generic_files << a_file
         a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
         a_work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
         a_work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC

--- a/spec/factories/generic_files.rb
+++ b/spec/factories/generic_files.rb
@@ -21,7 +21,7 @@ FactoryGirl.define do
         if evaluator.content
           Hydra::Works::UploadFileToGenericFile.call(file, evaluator.content)
         end
-        Hydra::Works::AddGenericFileToGenericWork.call(FactoryGirl.create(:generic_work, user: evaluator.user), file)
+        FactoryGirl.create(:generic_work, user: evaluator.user).generic_files << file
       end
     end
     after(:build) do |file, evaluator|

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -20,12 +20,12 @@ FactoryGirl.define do
 
     factory :work_with_one_file do
       before(:create) do |work, evaluator|
-        Hydra::Works::AddGenericFileToGenericWork.call(work, FactoryGirl.create(:generic_file, user: evaluator.user, title:['A Contained Generic File'], filename:['filename.pdf']))
+        work.generic_files << FactoryGirl.create(:generic_file, user: evaluator.user, title:['A Contained Generic File'], filename:['filename.pdf'])
       end
     end
 
     factory :work_with_files do
-      before(:create) { |work, evaluator| 2.times { Hydra::Works::AddGenericFileToGenericWork.call(work, FactoryGirl.create(:generic_file, user: evaluator.user)) } }
+      before(:create) { |work, evaluator| 2.times { work.generic_files << FactoryGirl.create(:generic_file, user: evaluator.user) } }
     end
 
     factory :with_embargo_date do
@@ -38,7 +38,7 @@ FactoryGirl.define do
 
       factory :embargoed_work_with_files do
         after(:build) { |work, evaluator| work.apply_embargo(evaluator.embargo_date, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
-        after(:create) { |work, evaluator| 2.times { Hydra::Works::AddGenericFileToGenericWork.call(work, FactoryGirl.create(:generic_file, user: evaluator.user)) } }
+        after(:create) { |work, evaluator| 2.times { work.generic_files << FactoryGirl.create(:generic_file, user: evaluator.user) } }
       end
 
       factory :leased_work do
@@ -47,7 +47,7 @@ FactoryGirl.define do
 
       factory :leased_work_with_files do
         after(:build) { |work, evaluator| work.apply_lease(evaluator.embargo_date, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) }
-        after(:create) { |work, evaluator| 2.times { Hydra::Works::AddGenericFileToGenericWork.call(work, FactoryGirl.create(:generic_file, user: evaluator.user)) } }
+        after(:create) { |work, evaluator| 2.times { work.generic_files << FactoryGirl.create(:generic_file, user: evaluator.user) } }
       end
     end
   end

--- a/spec/jobs/audit_job_spec.rb
+++ b/spec/jobs/audit_job_spec.rb
@@ -6,7 +6,7 @@ describe AuditJob do
   let(:file) do
     generic_file = GenericFile.create do |file|
       file.apply_depositor_metadata(user)
-      Hydra::Works::AddFileToGenericFile.call(file, fixture_file_path('world.png'), :original_file, versioning: true)
+      Hydra::Works::AddFileToGenericFile.call(file, File.open(fixture_file_path('world.png')), :original_file, versioning: true)
     end
   end
 

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -6,7 +6,7 @@ describe CharacterizeJob do
   let(:generic_file) do
     GenericFile.create do |file|
       file.apply_depositor_metadata(user)
-      Hydra::Works::AddFileToGenericFile.call(file, fixture_path + '/charter.docx', :original_file, original_name: 'charter.docx')
+      Hydra::Works::AddFileToGenericFile.call(file, File.open(fixture_file_path('charter.docx')), :original_file)
     end
   end
 

--- a/spec/models/curation_concerns/collection_behavior_spec.rb
+++ b/spec/models/curation_concerns/collection_behavior_spec.rb
@@ -79,11 +79,11 @@ describe CurationConcerns::CollectionBehavior do
       expect(subject.type).to_not include RDFVocabularies::PCDMTerms.Object
     end
     it 'should have child objects' do
-      expect(subject.child_objects).to eq []
-      expect(subject.child_object_ids).to eq []
-      expect(subject.child_objects << work1).to eq [work1]
-      expect(subject.child_objects).to eq [work1]
-      expect(subject.child_object_ids).to eq [work1.id]
+      expect(subject.child_generic_works).to eq []
+      expect(subject.child_generic_work_ids).to eq []
+      expect(subject.child_generic_works << work1).to eq [work1]
+      expect(subject.child_generic_works).to eq [work1]
+      expect(subject.child_generic_work_ids).to eq [work1.id]
     end
     it 'should have child collections' do
       expect(subject.child_collections).to eq []

--- a/spec/models/fits_datastream_spec.rb
+++ b/spec/models/fits_datastream_spec.rb
@@ -4,7 +4,7 @@ describe FitsDatastream, type: :model, unless: $in_travis do
   describe "image" do
     before(:all) do
       @file = GenericFile.create { |gf| gf.apply_depositor_metadata('blah') }
-      Hydra::Works::AddFileToGenericFile.call(@file, File.join(fixture_path + '/world.png'), :original_file)
+      Hydra::Works::AddFileToGenericFile.call(@file, File.open(fixture_file_path('world.png')), :original_file)
       CurationConcerns::CharacterizationService.run(@file)
     end
     it "has a format label" do
@@ -44,7 +44,7 @@ describe FitsDatastream, type: :model, unless: $in_travis do
   describe "video" do
     before(:all) do
       @file = GenericFile.create { |gf| gf.apply_depositor_metadata('blah') }
-      Hydra::Works::AddFileToGenericFile.call(@file, File.join(fixture_path + '/sample_mpeg4.mp4'), :original_file)
+      Hydra::Works::AddFileToGenericFile.call(@file, File.open(fixture_file_path('sample_mpeg4.mp4')), :original_file)
       CurationConcerns::CharacterizationService.run(@file)
     end
     it "has a format label" do
@@ -86,7 +86,7 @@ describe FitsDatastream, type: :model, unless: $in_travis do
   describe "pdf" do
     before do
       @myfile = GenericFile.create { |gf| gf.apply_depositor_metadata('blah') }
-      Hydra::Works::AddFileToGenericFile.call(@myfile, File.join(fixture_path + '/test4.pdf'), :original_file)
+      Hydra::Works::AddFileToGenericFile.call(@myfile, File.open(fixture_file_path('test4.pdf')), :original_file)
       # characterize method saves
       CurationConcerns::CharacterizationService.run(@myfile)
     end
@@ -113,7 +113,7 @@ describe FitsDatastream, type: :model, unless: $in_travis do
   describe "m4a" do
     before do
       @myfile = GenericFile.create { |gf| gf.apply_depositor_metadata('blah') }
-      Hydra::Works::AddFileToGenericFile.call(@myfile, File.join(fixture_path + '/spoken-text.m4a'), :original_file)
+      Hydra::Works::AddFileToGenericFile.call(@myfile, File.open(fixture_file_path('spoken-text.m4a')), :original_file)
       # characterize method saves
       CurationConcerns::CharacterizationService.run(@myfile)
     end

--- a/spec/services/characterization_service_spec.rb
+++ b/spec/services/characterization_service_spec.rb
@@ -16,7 +16,7 @@ describe CurationConcerns::CharacterizationService do
   describe "characterize", unless: $in_travis do
     subject   { described_class.new(generic_file) }
     before do
-      Hydra::Works::UploadFileToGenericFile.call(generic_file, fixture_path + '/charter.docx', original_name: 'charter.docx')
+      Hydra::Works::UploadFileToGenericFile.call(generic_file, File.open(fixture_file_path('charter.docx')))
     end
     it "characterizes, extracts fulltext and stores the results" do
       expect(subject).to receive(:extract_fulltext).and_return("The fulltext")

--- a/spec/services/create_derivatives_service_spec.rb
+++ b/spec/services/create_derivatives_service_spec.rb
@@ -15,7 +15,7 @@ describe CurationConcerns::CreateDerivativesService do
 
   describe 'thumbnail generation' do
     before do
-      Hydra::Works::AddFileToGenericFile.call(@generic_file, File.join(fixture_path, file_name), :original_file)
+      Hydra::Works::AddFileToGenericFile.call(@generic_file, File.open(fixture_file_path(file_name)), :original_file)
       allow_any_instance_of(GenericFile).to receive(:mime_type).and_return(mime_type)
       @generic_file.save!
     end
@@ -84,7 +84,7 @@ describe CurationConcerns::CreateDerivativesService do
 
   describe 'audiovisual transcoding' do
     before do
-      Hydra::Works::AddFileToGenericFile.call(@generic_file, File.join(fixture_path, file_name), :original_file)
+      Hydra::Works::AddFileToGenericFile.call(@generic_file, File.open(fixture_file_path(file_name)), :original_file)
       allow_any_instance_of(GenericFile).to receive(:mime_type).and_return(mime_type)
       @generic_file.save!
     end

--- a/spec/services/generic_file_audit_service_spec.rb
+++ b/spec/services/generic_file_audit_service_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe CurationConcerns::GenericFileAuditService do
-  let(:f)       { FactoryGirl.create(:generic_file, content: fixture_path + '/world.png' )}
+  let(:f)       { FactoryGirl.create(:generic_file, content: File.open(fixture_file_path('world.png')) )}
   let(:service) { CurationConcerns::GenericFileAuditService.new(f) }
 
   describe "#audit" do

--- a/spec/services/versioning_service_spec.rb
+++ b/spec/services/versioning_service_spec.rb
@@ -10,7 +10,7 @@ describe CurationConcerns::VersioningService do
 
     before do
       # Add the original_file (this service  creates a version after saving when you call it with versioning: true)
-      Hydra::Works::AddFileToGenericFile.call(file, fixture_file_path('world.png'), :original_file, versioning: true)
+      Hydra::Works::AddFileToGenericFile.call(file, File.open(fixture_file_path('world.png')), :original_file, versioning: true)
     end
 
     describe  "latest_version_of" do

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,11 +1,11 @@
 gem 'hydra-head', github:'projecthydra/hydra-head'
-gem 'hydra-derivatives', github: 'projecthydra/hydra-derivatives', ref: '7a8377c'
+gem 'hydra-derivatives', github: 'projecthydra/hydra-derivatives', ref: '44d00bd'
 
-gem 'active-fedora', github: 'projecthydra/active_fedora', ref: '4d0e9fdc'
-gem 'activefedora-aggregation', github: 'projecthydra-labs/activefedora-aggregation', ref: '59bfd35'
-gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm', ref: '378a6fb'
-gem 'hydra-works', github: 'projecthydra-labs/hydra-works', ref: 'fac9bc2'
+gem 'active-fedora', github: 'projecthydra/active_fedora', ref: 'bd506dc'
+gem 'activefedora-aggregation', github: 'projecthydra-labs/activefedora-aggregation', ref: 'fb967dd'
+gem 'hydra-pcdm', github: 'projecthydra-labs/hydra-pcdm', ref: '75b2181'
+gem 'hydra-works', github: 'projecthydra-labs/hydra-works', ref: '8472b2c'
 
 gem 'active-triples'
 gem 'active_fedora-noid', github: 'projecthydra-labs/active_fedora-noid', ref: '38079e4'
-gem 'hydra-collections', github: 'projecthydra/hydra-collections', ref: '6178fa4'
+gem 'hydra-collections', github: 'projecthydra/hydra-collections', ref: '08a2d77'


### PR DESCRIPTION
 - Removed `Hydra::Works::AddGenericFileToGenericWork` calls, deprecated as of https://github.com/projecthydra-labs/hydra-works/pull/161. Closes #138.
 - Pass file object rather than path to reflect updated `Hydra::Works::AddFileToGenericFile` and `Hydra::Works::UploadFileToGenericFile` as of https://github.com/projecthydra-labs/hydra-works/pull/154. Closes #101.