### PR TITLE
Adding in the single use link model, generation controller, and view controller

### DIFF
--- a/app/controllers/concerns/curation_concerns/single_use_links_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/single_use_links_controller_behavior.rb
@@ -1,0 +1,48 @@
+module CurationConcerns
+  module SingleUseLinksControllerBehavior
+    extend ActiveSupport::Concern
+    included do
+      before_action :authenticate_user!
+      before_action :authorize_user!
+      # Catch permission errors
+      rescue_from Hydra::AccessDenied, CanCan::AccessDenied do |exception|
+        if current_user && current_user.persisted?
+          redirect_to main_app.root_url, alert: "You do not have sufficient privileges to create links to this document"
+        else
+          session["user_return_to"] = request.url
+          redirect_to new_user_session_url, alert: exception.message
+        end
+      end
+    end
+
+    def new_download
+      @su = SingleUseLink.create itemId: params[:id], path: main_app.download_path(id: asset)
+      @link = curation_concerns.download_single_use_link_path(@su.downloadKey)
+
+      respond_to do |format|
+        format.html
+        format.js { render js: @link }
+      end
+    end
+
+    def new_show
+      @su = SingleUseLink.create itemId: params[:id], path: polymorphic_path([main_app, :curation_concerns, asset])
+      @link = curation_concerns.show_single_use_link_path(@su.downloadKey)
+
+      respond_to do |format|
+        format.html
+        format.js { render js: @link }
+      end
+    end
+
+    protected
+
+      def authorize_user!
+        authorize! :edit, asset
+      end
+
+      def asset
+        @asset ||= ActiveFedora::Base.load_instance_from_solr(params[:id])
+      end
+  end
+end

--- a/app/controllers/concerns/curation_concerns/single_use_links_viewer_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/single_use_links_viewer_controller_behavior.rb
@@ -1,0 +1,70 @@
+module CurationConcerns
+  module SingleUseLinksViewerControllerBehavior
+    extend ActiveSupport::Concern
+    include CurationConcerns::DownloadBehavior
+    include Blacklight::Base
+    include Hydra::Controller::SearchBuilder
+
+    included do
+      include ActionDispatch::Routing::PolymorphicRoutes
+
+      skip_before_action :authorize_download!, only: :show
+      rescue_from CurationConcerns::SingleUseError, with: :render_single_use_error
+      rescue_from CanCan::AccessDenied, with: :render_single_use_error
+      rescue_from ActiveRecord::RecordNotFound, with: :render_single_use_error
+      class_attribute :presenter_class
+      self.presenter_class = CurationConcerns::GenericFilePresenter
+      copy_blacklight_config_from(::CatalogController)
+    end
+
+    def download
+      raise not_found_exception unless single_use_link.path == main_app.download_path(id: @asset)
+      send_content
+    end
+
+    def show
+      _, document_list = search_results({ id: single_use_link.itemId }, [:find_one])
+      curation_concern = document_list.first
+
+      # Authorize using SingleUseLinksViewerController::Ability
+      authorize! :read, curation_concern
+
+      raise not_found_exception unless single_use_link.path == polymorphic_path([main_app, :curation_concerns, curation_concern])
+
+      # show the file
+      @presenter = presenter_class.new(curation_concern, current_ability)
+
+      # create a dowload link that is single use for the user since we do not just want to show metadata we want to access it too
+      @su = single_use_link.create_for_path main_app.download_path(curation_concern.id)
+      @download_link = curation_concerns.download_single_use_link_path(@su.downloadKey)
+    end
+
+    protected
+
+      # This is called in a before filter. It causes @asset to be set.
+      def authorize_download!
+        authorize! :read, asset
+      end
+
+      def single_use_link
+        @single_use_link ||= SingleUseLink.find_by_downloadKey!(params[:id])
+      end
+
+      def not_found_exception
+        CurationConcerns::SingleUseError.new('Single-Use Link Not Found')
+      end
+
+      def asset
+        @asset ||= ActiveFedora::Base.find(single_use_link.itemId)
+      end
+
+      def current_ability
+        @current_ability ||= SingleUseLinksViewerController::Ability.new current_user, single_use_link
+      end
+
+      def render_single_use_error(exception)
+        logger.error("Rendering PAGE due to exception: #{exception.inspect} - #{exception.backtrace if exception.respond_to? :backtrace}")
+        render template: '/error/single_use_error', layout: "error", formats: [:html], status: 404
+      end
+  end
+end

--- a/app/controllers/curation_concerns/single_use_links_controller.rb
+++ b/app/controllers/curation_concerns/single_use_links_controller.rb
@@ -1,0 +1,5 @@
+module CurationConcerns
+  class SingleUseLinksController < ApplicationController
+    include CurationConcerns::SingleUseLinksControllerBehavior
+  end
+end

--- a/app/controllers/curation_concerns/single_use_links_viewer_controller.rb
+++ b/app/controllers/curation_concerns/single_use_links_viewer_controller.rb
@@ -1,0 +1,21 @@
+module CurationConcerns
+  class SingleUseLinksViewerController < ApplicationController
+    include CurationConcerns::SingleUseLinksViewerControllerBehavior
+
+    class Ability
+      include CanCan::Ability
+
+      attr_reader :single_use_link
+
+      def initialize(user, single_use_link)
+        @user = user || ::User.new
+
+        @single_use_link = single_use_link
+
+        can :read, [ActiveFedora::Base, SolrDocument] do |obj|
+          single_use_link.valid? && single_use_link.itemId == obj.id && single_use_link.destroy!
+        end if single_use_link
+      end
+    end
+  end
+end

--- a/app/views/curation_concerns/single_use_links/new_download.html.erb
+++ b/app/views/curation_concerns/single_use_links/new_download.html.erb
@@ -1,0 +1,5 @@
+<div class="single-use-link">
+<h1>Single Use Link</h1>
+<p>Anyone can use the following link once to download the file</p>
+<%= link_to @asset, @link, class: 'download-link', data: { 'no-turbolink' => ''}, target: '_blank' %>
+</div>

--- a/app/views/curation_concerns/single_use_links/new_show.html.erb
+++ b/app/views/curation_concerns/single_use_links/new_show.html.erb
@@ -1,0 +1,5 @@
+<div class="single-use-link">
+<h1>Single Use Link</h1>
+<p>Anyone can use the following link once to view the file metadata</p>
+<%= link_to @asset, @link, target: '_blank' %>
+</div>

--- a/app/views/curation_concerns/single_use_links_viewer/show.html.erb
+++ b/app/views/curation_concerns/single_use_links_viewer/show.html.erb
@@ -1,0 +1,10 @@
+<div >
+  <h1 class="lower"><%= @asset %></h1>
+    <h2 class="non lower">Actions</h2>
+    <p>
+      <%= link_to "Download (can only be used once)", @download_link, target: '_blank', data: { 'no-turbolink' => ''} %>
+    </p>
+  <h2> Descriptions:</h2>
+
+  <%= render 'curation_concerns/base/attributes' %>
+</div>

--- a/app/views/error/single_use_error.html.erb
+++ b/app/views/error/single_use_error.html.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="<%= t("curation_concerns.document_language") %>">
+  <head>
+    <title>Single use link Not Found</title>
+  </head>
+  <body>
+    <div class="columns two-a">
+      <div class="column second">
+        <h1>Single Use Link Expired or Not Found</h1>
+        <p>
+          <%= t('curation_concerns.product_name') %> could not locate the single use link.
+          This link either expired or had been used previously.  We apologize
+          for the inconvenience. You might be interested in using
+          <a href="/help/">the help page</a> for looking up
+          solutions.
+        </p>
+      </div>
+  </body>
+</html>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="<%= t("curation_concerns.document_language") %>">
+  <head>
+    <meta charset="utf-8" />
+
+    <title><%= h(application_name) %>: System Error</title>
+    <!-- application css -->
+    <%= stylesheet_link_tag 'application' %>
+
+    <!-- application js -->
+    <%= javascript_include_tag 'application' %>
+
+    <%= render partial: 'shared/ga', formats: [:html] %>
+  </head>
+
+<body>
+<div  id="wrapper">
+  <div class="container-fluid">
+    <div id="page-positioner">
+      <div id="content-wrapper">
+        <div id="content" class="row">
+            <div class="col-sm-8 col-md-8 col-lg-8">
+              <%= yield %>
+            </div>
+        </div><!-- /#content -->
+      </div><!-- /#content-wrapper -->
+      <%= render partial: 'shared/footer' %>
+    </div><!-- /#page-positioner -->
+  </div><!-- /.container -->
+</div><!-- /#wrapper -->
+</body>
+
+</html>

--- a/app/views/records/_rights_modal.html.erb
+++ b/app/views/records/_rights_modal.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "generic_files/rights_modal" %>

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,0 +1,5 @@
+<% if f.object.class.multiple? key %>
+  <%= f.input key, as: :multi_value_with_help, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, required: f.object.required?(key) %>
+<% end %>

--- a/app/views/records/show_fields/_default.html.erb
+++ b/app/views/records/show_fields/_default.html.erb
@@ -1,0 +1,6 @@
+<% Array(record[key]).each do |v| %>
+  <span itemprop="<%= key %>" itemscope itemtype="http://schema.org/Thing">
+    <%= v %>
+  </span>
+  <br />
+<% end %>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -7,6 +7,7 @@ en:
     division:
       name: "Your Division at Institution"
       homepage_url: "#"
+    document_language: "en"
     google_analytics_id: ""
     institution:
       name: "Your Institution"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 CurationConcerns::Engine.routes.draw do
+  get 'single_use_link/show/:id' => 'single_use_links_viewer#show', as: :show_single_use_link
+  get 'single_use_link/download/:id' => 'single_use_links_viewer#download', as: :download_single_use_link
+  get 'single_use_link/generate_download/:id' => 'single_use_links#new_download', as: :generate_download_single_use_link
+  get 'single_use_link/generate_show/:id' => 'single_use_links#new_show', as: :generate_show_single_use_link
+
   # mount BrowseEverything::Engine => '/remote_files/browse'
   resources :classify_concerns, only: [:new, :create]
 end

--- a/curation_concerns-models/app/models/single_use_link.rb
+++ b/curation_concerns-models/app/models/single_use_link.rb
@@ -1,0 +1,34 @@
+class SingleUseLink < ActiveRecord::Base
+  validate :expiration_date_cannot_be_in_the_past
+  validate :cannot_be_destroyed
+
+  after_initialize :set_defaults
+
+  def create_for_path(path)
+    self.class.create(itemId: itemId, path: path)
+  end
+
+  def expired?
+    DateTime.now > expires
+  end
+
+  def to_param
+    downloadKey
+  end
+
+  protected
+
+    def expiration_date_cannot_be_in_the_past
+      errors.add(:expires, "can't be in the past") if expired?
+    end
+
+    def cannot_be_destroyed
+      errors[:base] << "Single Use Link has already been used" if destroyed?
+    end
+
+    def set_defaults
+      return unless new_record?
+      self.expires ||= DateTime.now.advance(hours: 24)
+      self.downloadKey ||= (Digest::SHA2.new << rand(1_000_000_000).to_s).to_s
+    end
+end

--- a/curation_concerns-models/lib/generators/curation_concerns/models/install_generator.rb
+++ b/curation_concerns-models/lib/generators/curation_concerns/models/install_generator.rb
@@ -18,7 +18,8 @@ This generator makes the following changes to your application:
   def copy_migrations
     [
       'create_version_committers.rb',
-      'create_checksum_audit_logs.rb' # ,
+      'create_checksum_audit_logs.rb',
+      'create_single_use_links.rb' # ,
     ].each do |file|
       better_migration_template file
     end

--- a/curation_concerns-models/lib/generators/curation_concerns/models/templates/migrations/create_single_use_links.rb
+++ b/curation_concerns-models/lib/generators/curation_concerns/models/templates/migrations/create_single_use_links.rb
@@ -1,0 +1,12 @@
+class CreateSingleUseLinks < ActiveRecord::Migration
+  def change
+    create_table :single_use_links do |t|
+      t.string :downloadKey
+      t.string :path
+      t.string :itemId
+      t.datetime :expires
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/curation_concerns/single_use_error.rb
+++ b/lib/curation_concerns/single_use_error.rb
@@ -1,0 +1,3 @@
+module CurationConcerns
+  class SingleUseError < StandardError; end
+end

--- a/spec/controllers/curation_concerns/single_use_links_controller_spec.rb
+++ b/spec/controllers/curation_concerns/single_use_links_controller_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe CurationConcerns::SingleUseLinksController, type: :controller do
+  routes { CurationConcerns::Engine.routes }
+  let(:user) { FactoryGirl.find_or_create(:jill) }
+
+  let(:file) do
+    GenericFile.create do |file|
+      file.apply_depositor_metadata(user)
+    end
+  end
+
+  describe "logged in user with edit permission" do
+    let(:hash) { "some-dummy-sha2-hash" }
+
+    before do
+      sign_in user
+      allow(DateTime).to receive(:now).and_return(DateTime.now)
+      expect(Digest::SHA2).to receive(:new).and_return(hash)
+    end
+
+    describe "GET 'download'" do
+      it "and_return http success" do
+        get 'new_download', id: file
+        expect(response).to be_success
+        expect(assigns[:link]).to eq routes.url_helpers.download_single_use_link_path(hash)
+      end
+    end
+
+    describe "GET 'show'" do
+      it "and_return http success" do
+        get 'new_show', id: file
+        expect(response).to be_success
+        expect(assigns[:link]).to eq routes.url_helpers.show_single_use_link_path(hash)
+      end
+    end
+  end
+
+  describe "logged in user without edit permission" do
+    before do
+      @other_user = FactoryGirl.find_or_create(:archivist)
+      file.read_users << @other_user
+      file.save
+      sign_in @other_user
+      file.read_users << @other_user
+      file.save
+    end
+
+    describe "GET 'download'" do
+      it "and_return http success" do
+        get 'new_download', id: file
+        expect(response).not_to be_success
+      end
+    end
+
+    describe "GET 'show'" do
+      it "and_return http success" do
+        get 'new_show', id: file
+        expect(response).not_to be_success
+      end
+    end
+  end
+
+  describe "unknown user" do
+    describe "GET 'download'" do
+      it "and_return http failure" do
+        get 'new_download', id: file
+        expect(response).not_to be_success
+      end
+    end
+
+    describe "GET 'show'" do
+      it "and_return http failure" do
+        get 'new_show', id: file
+        expect(response).not_to be_success
+      end
+    end
+  end
+end

--- a/spec/controllers/curation_concerns/single_use_links_viewer_controller_spec.rb
+++ b/spec/controllers/curation_concerns/single_use_links_viewer_controller_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe CurationConcerns::SingleUseLinksViewerController do
+  routes { CurationConcerns::Engine.routes }
+  let(:file) do
+    file = GenericFile.create do |lfile|
+      lfile.label = 'world.png'
+      lfile.apply_depositor_metadata('mjg')
+    end
+    Hydra::Works::AddFileToGenericFile.call(file, File.open(fixture_path + '/world.png'), :original_file)
+    file
+  end
+
+  describe "retrieval links" do
+    let :show_link do
+      SingleUseLink.create itemId: file.id, path: Rails.application.routes.url_helpers.curation_concerns_generic_file_path(id: file)
+    end
+
+    let :download_link do
+      SingleUseLink.create itemId: file.id, path: Rails.application.routes.url_helpers.download_path(id: file)
+    end
+
+    let :show_link_hash do
+      show_link.downloadKey
+    end
+
+    let :download_link_hash do
+      download_link.downloadKey
+    end
+
+    describe "GET 'download'" do
+      let(:expected_content) { ActiveFedora::Base.find(file.id).original_file.content }
+
+      it "and_return http success" do
+        expect(controller).to receive(:send_file_headers!).with(filename: 'world.png', disposition: 'inline', type: 'image/png')
+        get :download, id: download_link_hash
+        expect(response.body).to eq expected_content
+        expect(response).to be_success
+        expect { SingleUseLink.find_by_downloadKey!(download_link_hash) }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      context "and the key is not found" do
+        before { SingleUseLink.find_by_downloadKey!(download_link_hash).destroy }
+
+        it "returns 404 if the key is not present" do
+          get :download, id: download_link_hash
+          expect(response).to render_template('error/single_use_error')
+        end
+      end
+    end
+
+    describe "GET 'show'" do
+      it "and_return http success" do
+        get 'show', id: show_link_hash
+        expect(response).to be_success
+        expect(assigns[:presenter].id).to eq file.id
+        expect { SingleUseLink.find_by_downloadKey!(show_link_hash) }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      context "and the key is not found" do
+        before { SingleUseLink.find_by_downloadKey!(show_link_hash).destroy }
+        it "returns 404 if the key is not present" do
+          get :show, id: show_link_hash
+          expect(response).to render_template('error/single_use_error')
+        end
+      end
+
+      it "returns 404 on attempt to get show path with download hash" do
+        get :show, id: download_link_hash
+        expect(response).to render_template('error/single_use_error')
+      end
+    end
+  end
+end

--- a/spec/models/single_use_link_spec.rb
+++ b/spec/models/single_use_link_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe SingleUseLink do
+  let(:file) { GenericFile.new(id: 'abc123') }
+  let(:now) { DateTime.now }
+  let(:hash) { "sha2hash#{now.to_f}" }
+
+  describe "create" do
+    subject { described_class.create itemId: file.id, path: path }
+
+    before do
+      allow(DateTime).to receive(:now).and_return(now)
+      expect(Digest::SHA2).to receive(:new).and_return(hash)
+    end
+    after do
+      subject.delete
+    end
+
+    describe "show" do
+      let(:path) { Rails.application.routes.url_helpers.curation_concerns_generic_file_path(file.id) }
+
+      it "creates link" do
+        expect(subject.downloadKey).to eq(hash)
+        expect(subject.itemId).to eq(file.id)
+        expect(subject.path).to eq(Rails.application.routes.url_helpers.curation_concerns_generic_file_path(file.id))
+      end
+    end
+    describe "download" do
+      let(:path) { Rails.application.routes.url_helpers.download_path(file.id) }
+
+      it "creates link" do
+        expect(subject.downloadKey).to eq(hash)
+        expect(subject.itemId).to eq(file.id)
+        expect(subject.path).to eq(Rails.application.routes.url_helpers.download_path(file.id))
+      end
+    end
+  end
+  describe "find" do
+    describe "not expired" do
+      before do
+        @su = described_class.create(downloadKey: 'sha2hashb', itemId: file.id, path: Rails.application.routes.url_helpers.download_path(file), expires: DateTime.now.advance(hours: 1))
+      end
+      it "retrieves link" do
+        link = described_class.where(downloadKey: 'sha2hashb').first
+        expect(link.itemId).to eq(file.id)
+      end
+      it "retrieves link with find_by" do
+        link = described_class.find_by_downloadKey('sha2hashb')
+        expect(link.itemId).to eq(file.id)
+      end
+      it "expires link" do
+        link = described_class.where(downloadKey: 'sha2hashb').first
+        expect(link.expired?).to eq(false)
+      end
+    end
+    describe "expired" do
+      before do
+        @su = described_class.create!(downloadKey: 'sha2hashb', itemId: file.id, path: Rails.application.routes.url_helpers.download_path(file))
+
+        @su.update_attribute :expires, DateTime.now.advance(hours: -1)
+      end
+
+      it "expires link" do
+        link = described_class.where(downloadKey: 'sha2hashb').first
+        expect(link.expired?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/routing/curation_concerns/routes_spec.rb
+++ b/spec/routing/curation_concerns/routes_spec.rb
@@ -14,6 +14,32 @@ module CurationConcerns
       end
     end
 
+    describe 'Single Use Link Viewer' do
+      routes { CurationConcerns::Engine.routes }
+      it 'routes to #show' do
+        expect(show_single_use_link_path('abc123')).to eq '/single_use_link/show/abc123'
+        expect(get("/single_use_link/show/abc123")).to route_to("curation_concerns/single_use_links_viewer#show", id: 'abc123')
+      end
+
+      it 'routes to #download' do
+        expect(download_single_use_link_path('abc123')).to eq '/single_use_link/download/abc123'
+        expect(get("/single_use_link/download/abc123")).to route_to("curation_concerns/single_use_links_viewer#download", id: 'abc123')
+      end
+    end
+
+    describe 'Single Use Link Generator' do
+      routes { CurationConcerns::Engine.routes }
+      it 'routes to #show' do
+        expect(generate_show_single_use_link_path('abc123')).to eq '/single_use_link/generate_show/abc123'
+        expect(get("/single_use_link/generate_show/abc123")).to route_to("curation_concerns/single_use_links#new_show", id: 'abc123')
+      end
+
+      it 'routes to #download' do
+        expect(generate_download_single_use_link_path('abc123')).to eq '/single_use_link/generate_download/abc123'
+        expect(get("/single_use_link/generate_download/abc123")).to route_to("curation_concerns/single_use_links#new_download", id: 'abc123')
+      end
+    end
+
     describe 'generic work' do
       routes { Rails.application.routes }
       let(:generic_work) { @generic_work }

--- a/spec/views/error/single_use_error.html.erb_spec.rb
+++ b/spec/views/error/single_use_error.html.erb_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'error/single_use_error.html.erb' do
+  it 'renders without errors' do
+    render file: 'error/single_use_error'
+    expect(rendered).to have_text("Single Use Link Expired or Not Found")
+  end
+end

--- a/spec/views/layouts/error.html.erb_spec.rb
+++ b/spec/views/layouts/error.html.erb_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'layouts/error.html.erb' do
+  it 'renders without errors' do
+    render
+    expect(rendered).to have_css("footer")
+  end
+end

--- a/spec/views/single_use_links/new_download.html.erb_spec.rb
+++ b/spec/views/single_use_links/new_download.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'curation_concerns/single_use_links/new_download.html.erb' do
+  let(:user) { FactoryGirl.find_or_create(:jill) }
+  let(:file) do
+    GenericFile.create do |f|
+      f.add_file(File.open(fixture_path + '/world.png'), path: 'content', original_name: 'world.png')
+      f.label = 'world.png'
+      f.apply_depositor_metadata(user)
+    end
+  end
+
+  let(:hash) { "some-dummy-sha2-hash" }
+
+  before do
+    assign :asset, file
+    assign :link, CurationConcerns::Engine.routes.url_helpers.download_single_use_link_path(hash)
+    render
+  end
+
+  it "has the download link" do
+    expect(rendered).to have_selector "a.download-link"
+  end
+
+  it "has turbolinks disabled in the download link" do
+    expect(rendered).to have_selector "a.download-link[data-no-turbolink]"
+  end
+end

--- a/spec/views/single_use_links_viewer/show.html.erb_spec.rb
+++ b/spec/views/single_use_links_viewer/show.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'curation_concerns/single_use_links_viewer/show.html.erb' do
+  let(:file) do
+    GenericFile.create do |f|
+      f.add_file(File.open(fixture_path + '/world.png'), path: 'content', original_name: 'world.png')
+      f.label = 'world.png'
+      f.apply_depositor_metadata('jill')
+    end
+  end
+
+  let(:solr_document) { SolrDocument.new(has_model_ssim: ['GenericFile']) }
+  let(:ability) { double }
+
+  let(:hash) { "some-dummy-sha2-hash" }
+
+  before do
+    assign :asset, file
+    assign :download_link, CurationConcerns::Engine.routes.url_helpers.download_single_use_link_path(hash)
+    assign :presenter, CurationConcerns::GenericFilePresenter.new(solr_document, ability)
+    render
+  end
+
+  it "contains a download link" do
+    expect(rendered).to have_selector "a[href^='/single_use_link/download/']"
+  end
+
+  it "has turbolinks disabled in the download link" do
+    expect(rendered).to have_selector "a[data-no-turbolink][href^='/single_use_link/download/']"
+  end
+end


### PR DESCRIPTION
see #146 

This code is copied from Sufia.  The controllers, models, and views for generating and showing sungle use links are in this PR.  The javascript used in sufia to generate the link in the dashboard and copy it to the user clipboard is not.
