### PR TITLE
redis config should set the proper namespace

### DIFF
--- a/curation_concerns-models/lib/generators/curation_concerns/models/templates/config/redis_config.rb
+++ b/curation_concerns-models/lib/generators/curation_concerns/models/templates/config/redis_config.rb
@@ -10,6 +10,7 @@ if defined?(PhusionPassenger)
       $redis.client.disconnect if $redis
       $redis = Redis.new(host: config[:host], port: config[:port], thread_safe: true) rescue nil
       Resque.redis = $redis
+      Resque.redis.namespace = "#{CurationConcerns.config.redis_namespace}:#{Rails.env}"
       Resque.redis.client.reconnect if Resque.redis
     end
   end


### PR DESCRIPTION
After forking in passenger.  Otherwise the jobs will get pushed to the default (`resque`) namespace.  Same as https://github.com/projecthydra/sufia/commit/97944c038d22131b1e57a3867c2a5f3a2d859178