### PR TITLE
Removed CurationConcern::Models.config

### DIFF
--- a/curation_concerns-models/lib/curation_concerns/models/engine.rb
+++ b/curation_concerns-models/lib/curation_concerns/models/engine.rb
@@ -1,11 +1,5 @@
 module CurationConcerns
   module Models
-    def self.config(&block)
-      @@config ||= Engine::Configuration.new
-      yield @@config if block
-      @@config
-    end
-
     class Engine < ::Rails::Engine
       require 'curation_concerns/models/resque'
 


### PR DESCRIPTION
This method wasn't being used. Introduced in
https://github.com/projecthydra-labs/curation_concerns/commit/3f583d0d374693c9ef39abd242e48e9262b0f7d8#diff-f631d74c43aa7f83627974c711f37deeR4