### PR TITLE
Allow Rubocop to run on Ruby 2.1.

### DIFF
--- a/app/helpers/curation_concerns/search_paths_helper.rb
+++ b/app/helpers/curation_concerns/search_paths_helper.rb
@@ -1,11 +1,11 @@
 module CurationConcerns::SearchPathsHelper
   def search_path_for_my_works(opts = {})
-    params_for_my_works = { 'f[generic_type_sim][]': 'Work', works: 'mine' }
+    params_for_my_works = { 'f[generic_type_sim][]' => 'Work', works: 'mine' }
     main_app.catalog_index_path(params_for_my_works.merge(opts))
   end
 
   def search_path_for_my_collections(opts = {})
-    params_for_my_collections = { 'f[generic_type_sim][]': 'Collection', works: 'mine' }
+    params_for_my_collections = { 'f[generic_type_sim][]' => 'Collection', works: 'mine' }
     main_app.catalog_index_path(params_for_my_collections.merge(opts))
   end
 end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -67,7 +67,7 @@ describe 'collection' do
       @collection.apply_depositor_metadata(user_key)
       @collection.save
       sign_in user
-      visit main_app.catalog_index_path('f[generic_type_sim][]': 'Collection', works: 'mine')
+      visit main_app.catalog_index_path('f[generic_type_sim][]' => 'Collection', works: 'mine')
     end
 
     it 'deletes a collection' do


### PR DESCRIPTION
@cam156 was seeing 18 linting errors in Rubocop with Ruby 2.1, which was preventing her from running local specs. CurationConcerns does not *explictly* state that Ruby 2.1 is required. Thus, let's make this small syntax change to let the test suite run atop Ruby 2.1.