### PR TITLE
Refactor spec to not have false positive warnings

### DIFF
--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -144,7 +144,7 @@ describe CurationConcerns::GenericWorksController do
     it 'deletes the work' do
       delete :destroy, id: work_to_be_deleted
       expect(response).to redirect_to main_app.catalog_index_path
-      expect { GenericWork.find(work_to_be_deleted.id) }.to raise_error
+      expect(GenericWork).not_to exist(work_to_be_deleted.id)
     end
 
     context 'someone elses public work' do
@@ -160,7 +160,7 @@ describe CurationConcerns::GenericWorksController do
       before { allow_any_instance_of(User).to receive(:groups).and_return(['admin']) }
       it 'someone elses private work should delete the work' do
         delete :destroy, id: work_to_be_deleted
-        expect { GenericWork.find(work_to_be_deleted.id) }.to raise_error
+        expect(GenericWork).not_to exist(work_to_be_deleted.id)
       end
     end
   end


### PR DESCRIPTION
Previously there were two warnings like:
```
WARNING: Using the `raise_error` matcher without providing a specific
error or message risks false positives, since `raise_error` will match
when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
potentially allowing the expectation to pass without even executing the
method you are intending to call. Instead consider providing a specific
error class or message.
```