### PR TITLE
Index the filename without any text transformation

### DIFF
--- a/curation_concerns-models/app/services/curation_concerns/generic_file_indexing_service.rb
+++ b/curation_concerns-models/app/services/curation_concerns/generic_file_indexing_service.rb
@@ -3,7 +3,9 @@ module CurationConcerns
     def generate_solr_document
       super.tap do |solr_doc|
         solr_doc[Solrizer.solr_name('representative')] = object.representative
+        # Label is the actual file name. It's not editable by the user.
         solr_doc[Solrizer.solr_name('label')] = object.label
+        solr_doc[Solrizer.solr_name('label', :stored_sortable)] = object.label
         solr_doc[Solrizer.solr_name('file_format')] = object.file_format
         solr_doc[Solrizer.solr_name('file_format', :facetable)] = object.file_format
         solr_doc[Solrizer.solr_name(:file_size, :symbol)] = object.file_size[0]

--- a/spec/services/generic_file_indexing_service_spec.rb
+++ b/spec/services/generic_file_indexing_service_spec.rb
@@ -29,6 +29,9 @@ describe CurationConcerns::GenericFileIndexingService do
   end
 
   describe '#generate_solr_document' do
+    before do
+      allow(generic_file).to receive(:label).and_return('CastoriaAd.tiff')
+    end
     subject { described_class.new(generic_file).generate_solr_document }
 
     it 'has fields' do
@@ -44,6 +47,8 @@ describe CurationConcerns::GenericFileIndexingService do
       expect(subject[Solrizer.solr_name('creator')]).to eq ['Allah']
       expect(subject[Solrizer.solr_name('title')]).to eq ['The Work']
       expect(subject[Solrizer.solr_name('title', :facetable)]).to eq ['The Work']
+      expect(subject[Solrizer.solr_name('label')]).to eq 'CastoriaAd.tiff'
+      expect(subject[Solrizer.solr_name('label', :stored_sortable)]).to eq 'CastoriaAd.tiff'
       expect(subject[Solrizer.solr_name('description')]).to eq ['The work by Allah']
       expect(subject[Solrizer.solr_name('publisher')]).to eq ['Vertigo Comics']
       expect(subject[Solrizer.solr_name('subject')]).to eq ['Theology']


### PR DESCRIPTION
This enables you to do an exact find by filename without risking a
partial match as you would if you used label_tesim.