### PR TITLE
Set the Content-Length header for downloads

### DIFF
--- a/app/controllers/concerns/curation_concerns/download_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/download_behavior.rb
@@ -19,6 +19,7 @@ module CurationConcerns
         super
       when String
         # For derivatives stored on the local file system
+        response.headers['Content-Length'] = File.size(file).to_s
         send_file file, type: mime_type_for(file), disposition: 'inline'
       else
         render_404

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -54,6 +54,7 @@ describe DownloadsController do
           it 'sends requested file content' do
             get :show, id: generic_file, file: 'thumbnail'
             expect(response.body).to eq content
+            expect(response.headers['Content-Length']).to eq "4218"
           end
         end
 


### PR DESCRIPTION
Without a Content-Length header on an audio/video file the browser will either
not show a scrubber or disable it.