### PR TITLE
remove use of .add_file in spec

### DIFF
--- a/spec/views/single_use_links/new_download.html.erb_spec.rb
+++ b/spec/views/single_use_links/new_download.html.erb_spec.rb
@@ -2,18 +2,19 @@ require 'spec_helper'
 
 describe 'curation_concerns/single_use_links/new_download.html.erb' do
   let(:user) { FactoryGirl.find_or_create(:jill) }
-  let(:file) do
-    GenericFile.create do |f|
-      f.add_file(File.open(fixture_path + '/world.png'), path: 'content', original_name: 'world.png')
-      f.label = 'world.png'
-      f.apply_depositor_metadata(user)
+
+  let(:f) do
+    file = GenericFile.create do |gf|
+      gf.apply_depositor_metadata(user)
     end
+    Hydra::Works::AddFileToGenericFile.call(file, File.open(fixture_path + '/world.png'), :original_file)
+    file
   end
 
   let(:hash) { "some-dummy-sha2-hash" }
 
   before do
-    assign :asset, file
+    assign :asset, f
     assign :link, CurationConcerns::Engine.routes.url_helpers.download_single_use_link_path(hash)
     render
   end

--- a/spec/views/single_use_links_viewer/show.html.erb_spec.rb
+++ b/spec/views/single_use_links_viewer/show.html.erb_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe 'curation_concerns/single_use_links_viewer/show.html.erb' do
-  let(:file) do
-    GenericFile.create do |f|
-      f.add_file(File.open(fixture_path + '/world.png'), path: 'content', original_name: 'world.png')
-      f.label = 'world.png'
-      f.apply_depositor_metadata('jill')
+  let(:f) do
+    file = GenericFile.create do |gf|
+      gf.apply_depositor_metadata('jill')
     end
+    Hydra::Works::AddFileToGenericFile.call(file, File.open(fixture_path + '/world.png'), :original_file)
+    file
   end
 
   let(:solr_document) { SolrDocument.new(has_model_ssim: ['GenericFile']) }
@@ -15,7 +15,7 @@ describe 'curation_concerns/single_use_links_viewer/show.html.erb' do
   let(:hash) { "some-dummy-sha2-hash" }
 
   before do
-    assign :asset, file
+    assign :asset, f
     assign :download_link, CurationConcerns::Engine.routes.url_helpers.download_single_use_link_path(hash)
     assign :presenter, CurationConcerns::GenericFilePresenter.new(solr_document, ability)
     render


### PR DESCRIPTION
remove use of .add_file in spec.  Just these two files were affected:

spec/views/single_use_links/new_download.html.erb_spec.rb
spec/views/single_use_links_viewer/show.html.erb_spec.rb