### PR TITLE
Persist visibility settings to generic files.

### DIFF
--- a/curation_concerns-models/app/actors/curation_concerns/generic_file_actor.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/generic_file_actor.rb
@@ -36,12 +36,13 @@ module CurationConcerns
         ActiveFedora::Base.logger.warn 'unable to find batch to attach to'
       end
 
+      if assign_visibility?(generic_file_params)
+        interpret_visibility generic_file_params
+      end
       unless work_id.blank?
         work = ActiveFedora::Base.find(work_id)
 
-        if !((generic_file_params || {}).keys & %w(visibility embargo_release_date lease_expiration_date)).empty?
-          interpret_visibility generic_file_params
-        else
+        unless assign_visibility?(generic_file_params)
           copy_visibility(work, generic_file)
         end
         work.generic_files << generic_file
@@ -49,6 +50,10 @@ module CurationConcerns
         work.save
       end
       yield(generic_file) if block_given?
+    end
+
+    def assign_visibility?(generic_file_params = {})
+      !((generic_file_params || {}).keys & %w(visibility embargo_release_date lease_expiration_date)).empty?
     end
 
     def create_content(file)

--- a/spec/actors/curation_concerns/work_actor_spec.rb
+++ b/spec/actors/curation_concerns/work_actor_spec.rb
@@ -56,6 +56,7 @@ describe CurationConcerns::GenericWorkActor do
                 rights: ['http://creativecommons.org/licenses/by/3.0/us/'] }
             end
             it "applies it to attached files" do
+              allow(CharacterizeJob).to receive(:perform_later).and_return(true)
               subject.create
               file = curation_concern.generic_files.first
               expect(file).to be_persisted

--- a/spec/actors/curation_concerns/work_actor_spec.rb
+++ b/spec/actors/curation_concerns/work_actor_spec.rb
@@ -44,6 +44,26 @@ describe CurationConcerns::GenericWorkActor do
             expect(curation_concern.visibility_after_embargo).to eq 'open'
             expect(curation_concern.visibility).to eq 'authenticated'
           end
+          context "with attached files" do
+            let(:attributes) do
+              { title: ['New embargo'], visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO,
+                visibility_during_embargo: 'authenticated', embargo_release_date: date.to_s,
+                visibility_after_embargo: 'open', visibility_during_lease: 'open',
+                lease_expiration_date: '2014-06-12', visibility_after_lease: 'restricted',
+                files: [
+                  file
+                ],
+                rights: ['http://creativecommons.org/licenses/by/3.0/us/'] }
+            end
+            it "applies it to attached files" do
+              subject.create
+              file = curation_concern.generic_files.first
+              expect(file).to be_persisted
+              expect(file.visibility_during_embargo).to eq 'authenticated'
+              expect(file.visibility_after_embargo).to eq 'open'
+              expect(file.visibility).to eq 'authenticated'
+            end
+          end
         end
 
         context 'when embargo_release_date is in the past' do


### PR DESCRIPTION
When ingesting the visibility should be copied to the generic files.

Closes #253.