### PR TITLE
Standardize how date_uploaded and date_modified are set

### DIFF
--- a/curation_concerns-models/app/actors/curation_concerns/base_actor.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/base_actor.rb
@@ -48,7 +48,7 @@ module CurationConcerns
       end
 
       def apply_deposit_date
-        curation_concern.date_uploaded = Date.today
+        curation_concern.date_uploaded = CurationConcerns::TimeService.time_in_utc
       end
 
       def save
@@ -59,7 +59,7 @@ module CurationConcerns
         attributes[:rights] = Array(attributes[:rights]) if attributes.key? :rights
         remove_blank_attributes!
         curation_concern.attributes = attributes.symbolize_keys
-        curation_concern.date_modified = Date.today
+        curation_concern.date_modified = CurationConcerns::TimeService.time_in_utc
       end
 
       # If any attributes are blank remove them

--- a/curation_concerns-models/app/actors/curation_concerns/generic_file_actor.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/generic_file_actor.rb
@@ -25,9 +25,9 @@ module CurationConcerns
 
     def create_metadata(batch_id, work_id, generic_file_params = {})
       generic_file.apply_depositor_metadata(user)
-      time_in_utc = DateTime.now.new_offset(0)
-      generic_file.date_uploaded = time_in_utc
-      generic_file.date_modified = time_in_utc
+      now = CurationConcerns::TimeService.time_in_utc
+      generic_file.date_uploaded = now
+      generic_file.date_modified = now
       generic_file.creator = [user.user_key]
       # TODO: Remove this? see https://github.com/projecthydra-labs/curation_concerns/issues/27
       if batch_id && generic_file.respond_to?(:batch_id=)
@@ -86,7 +86,7 @@ module CurationConcerns
       update_visibility(all_attributes)
       model_attributes.delete(:visibility) # Applying this attribute is handled by update_visibility
       generic_file.attributes = model_attributes
-      generic_file.date_modified = DateTime.now
+      generic_file.date_modified = CurationConcerns::TimeService.time_in_utc
       save do
         if CurationConcerns.config.respond_to?(:after_update_metadata)
           CurationConcerns.config.after_update_metadata.call(generic_file, user)

--- a/curation_concerns-models/app/services/curation_concerns/time_service.rb
+++ b/curation_concerns-models/app/services/curation_concerns/time_service.rb
@@ -1,0 +1,7 @@
+module CurationConcerns
+  class TimeService
+    def self.time_in_utc
+      DateTime.now.utc
+    end
+  end
+end

--- a/spec/actors/curation_concerns/work_actor_spec.rb
+++ b/spec/actors/curation_concerns/work_actor_spec.rb
@@ -12,6 +12,7 @@ describe CurationConcerns::GenericWorkActor do
 
   describe '#create' do
     let(:curation_concern) { GenericWork.new }
+    let(:xmas) { DateTime.parse('2014-12-25 11:30') }
 
     context 'failure' do
       let(:attributes) { {} }
@@ -93,12 +94,16 @@ describe CurationConcerns::GenericWorkActor do
         end
 
         context 'authenticated visibility' do
+          before do
+            allow(CurationConcerns::TimeService).to receive(:time_in_utc) { xmas }
+          end
+
           it 'stamps each file with the access rights' do
             expect(CharacterizeJob).to receive(:perform_later)
             expect(subject.create).to be true
             expect(curation_concern).to be_persisted
-            expect(curation_concern.date_uploaded).to eq Date.today
-            expect(curation_concern.date_modified).to eq Date.today
+            expect(curation_concern.date_uploaded).to eq xmas
+            expect(curation_concern.date_modified).to eq xmas
             expect(curation_concern.depositor).to eq user.user_key
             expect(curation_concern.representative).to_not be_nil
             expect(curation_concern.generic_files.size).to eq 1
@@ -121,13 +126,17 @@ describe CurationConcerns::GenericWorkActor do
         end
 
         context 'authenticated visibility' do
+          before do
+            allow(CurationConcerns::TimeService).to receive(:time_in_utc) { xmas }
+          end
+
           it 'stamps each file with the access rights' do
             expect(CharacterizeJob).to receive(:perform_later).twice
 
             expect(subject.create).to be true
             expect(curation_concern).to be_persisted
-            expect(curation_concern.date_uploaded).to eq Date.today
-            expect(curation_concern.date_modified).to eq Date.today
+            expect(curation_concern.date_uploaded).to eq xmas
+            expect(curation_concern.date_modified).to eq xmas
             expect(curation_concern.depositor).to eq user.user_key
 
             expect(curation_concern.generic_files.size).to eq 2


### PR DESCRIPTION
I noticed that the date_uploaded and date_modified fields were being calculated different ways in different parts of the code.

Also see the comments in this story:
https://github.com/curationexperts/goldenseal/issues/84