### PR TITLE
Adding checking the work representative to the GenericFileActor. fixes #268

### DIFF
--- a/app/controllers/concerns/curation_concerns/generic_files_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/generic_files_controller_behavior.rb
@@ -66,7 +66,7 @@ module CurationConcerns
     end
 
     def destroy
-      @generic_file.destroy
+      actor.destroy
       redirect_to [main_app, :curation_concerns, @generic_file.generic_works.first], notice: 'The file has been deleted.'
     end
 

--- a/spec/actors/curation_concerns/generic_file_actor_spec.rb
+++ b/spec/actors/curation_concerns/generic_file_actor_spec.rb
@@ -122,4 +122,27 @@ describe CurationConcerns::GenericFileActor do
       expect(generic_file_with_label.label).to eql(label)
     end
   end
+
+  describe "#destroy" do
+    it "destroys the object" do
+      actor.destroy
+      expect { generic_file.reload }.to raise_error ActiveFedora::ObjectNotFoundError
+    end
+    context "representative of a work" do
+      let!(:work) do
+        work = FactoryGirl.create(:generic_work)
+        # this is not part of a block on the create, since the work must be saved be fore the representative can be assigned
+        work.generic_files << generic_file
+        work.representative = generic_file.id
+        work.save
+        work
+      end
+
+      it "removes representative" do
+        expect(work.reload.representative).to eq(generic_file.id)
+        actor.destroy
+        expect(work.reload.representative).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
In addition I changed the controller to use the actor to destroy the file.  This allows the call backs to be performed in addition to checking the work representative.