### PR TITLE
Add a way to add more response types.

### DIFF
--- a/app/controllers/concerns/curation_concerns/generic_files_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/generic_files_controller_behavior.rb
@@ -66,6 +66,7 @@ module CurationConcerns
           authorize! :show, @generic_file
           render :show, status: :ok
         end
+        additional_response_formats(wants)
       end
     end
 
@@ -123,6 +124,12 @@ module CurationConcerns
     end
 
     protected
+
+      # Override this method to add additional response
+      # formats to your local app
+      def additional_response_formats(_)
+        # nop
+      end
 
       def generic_file_params
         params.require(:generic_file).permit(

--- a/spec/controllers/curation_concerns/generic_files_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_files_controller_spec.rb
@@ -227,7 +227,7 @@ describe CurationConcerns::GenericFilesController do
       end
     end
 
-    describe '#view' do
+    describe '#show' do
       it 'allows access to the file' do
         get :show, id: public_generic_file
         expect(response).to be_success
@@ -246,12 +246,14 @@ describe CurationConcerns::GenericFilesController do
       end
     end
 
-    describe '#view' do
+    describe '#show' do
       it 'denies access to private files' do
         get :show, id: private_generic_file
         expect(response).to fail_redirect_and_flash(main_app.new_user_session_path, 'You are not authorized to access this page.')
       end
+
       it 'allows access to public files' do
+        expect(controller).to receive(:additional_response_formats).with(ActionController::MimeResponds::Collector)
         get :show, id: public_generic_file
         expect(response).to be_success
       end


### PR DESCRIPTION
For example if you want to add an XML response type, you can now just
override additional_response_formats. This pattern is copied from
Blacklight:
https://github.com/projectblacklight/blacklight/blob/master/lib/blacklight/catalog.rb#L143-L168