### PR TITLE
Save the embargo when removing it

### DIFF
--- a/app/controllers/concerns/curation_concerns/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/embargoes_controller_behavior.rb
@@ -12,9 +12,10 @@ module CurationConcerns
       authorize! :discover, Hydra::AccessControls::Embargo
     end
 
+    # Removes a single embargo
     def destroy
       update_files = !curation_concern.under_embargo? # embargo expired
-      remove_embargo(curation_concern)
+      EmbargoActor.new(curation_concern).destroy
       flash[:notice] = curation_concern.embargo_history.last
       if update_files
         redirect_to confirm_curation_concerns_permission_path(curation_concern)
@@ -23,12 +24,13 @@ module CurationConcerns
       end
     end
 
+    # Updates a batch of embargos
     def update
       filter_docs_with_edit_access!
       copy_visibility = params[:embargoes].values.map { |h| h[:copy_visibility] }
       batch.each do |id|
         ActiveFedora::Base.find(id).tap do |curation_concern|
-          remove_embargo(curation_concern)
+          EmbargoActor.new(curation_concern).destroy
           curation_concern.copy_visibility_to_files if copy_visibility.include?(id)
         end
       end
@@ -40,12 +42,6 @@ module CurationConcerns
       def _prefixes
         # This allows us to use the unauthorized template in curation_concerns/base
         @_prefixes ||= super + ['curation_concerns/base']
-      end
-
-      def remove_embargo(work)
-        work.embargo_visibility! # If the embargo has lapsed, update the current visibility.
-        work.deactivate_embargo!
-        work.save
       end
   end
 end

--- a/curation_concerns-models/app/actors/curation_concerns/embargo_actor.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/embargo_actor.rb
@@ -1,0 +1,19 @@
+module CurationConcerns
+  class EmbargoActor
+    attr_reader :work
+
+    # @param [Hydra::Works::Work] work
+    def initialize(work)
+      @work = work
+    end
+
+    # Update the visibility of the work to match the correct state of the embargo, then clear the embargo date, etc.
+    # Saves the embargo and the work
+    def destroy
+      work.embargo_visibility! # If the embargo has lapsed, update the current visibility.
+      work.deactivate_embargo!
+      work.embargo.save!
+      work.save!
+    end
+  end
+end

--- a/spec/actors/curation_concerns/embargo_actor_spec.rb
+++ b/spec/actors/curation_concerns/embargo_actor_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe CurationConcerns::EmbargoActor do
+  let(:actor) { described_class.new(work) }
+
+  let(:work) do
+    GenericWork.new do |work|
+      work.apply_depositor_metadata 'foo'
+      work.title = ["test"]
+      work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      work.embargo_release_date = release_date.to_s
+      work.save(validate: false)
+    end
+  end
+
+  describe "#destroy" do
+    context "with an active embargo" do
+      let(:release_date) { Date.today + 2 }
+
+      it "removes the embargo" do
+        actor.destroy
+        expect(work.reload.embargo_release_date).to be_nil
+        expect(work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      end
+    end
+
+    context 'with an expired embargo' do
+      let(:release_date) { Date.today - 2 }
+      it "removes the embargo" do
+        actor.destroy
+        expect(work.reload.embargo_release_date).to be_nil
+        expect(work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      end
+    end
+  end
+end

--- a/spec/controllers/embargoes_controller_spec.rb
+++ b/spec/controllers/embargoes_controller_spec.rb
@@ -50,19 +50,18 @@ describe EmbargoesController do
     context 'when I have permission to edit the object' do
       before do
         expect(ActiveFedora::Base).to receive(:find).with(a_work.id).and_return(a_work)
-        a_work.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-        a_work.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-        a_work.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         a_work.embargo_release_date = release_date.to_s
-        a_work.save(validate: false)
-        get :destroy, id: a_work
+        allow(CurationConcerns::EmbargoActor).to receive(:new).with(a_work).and_return(actor)
       end
+
+      let(:actor) { double }
 
       context 'with an active embargo' do
         let(:release_date) { Date.today + 2 }
 
         it 'deactivates embargo without updating visibility and redirect' do
-          expect(a_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+          expect(actor).to receive(:destroy)
+          get :destroy, id: a_work
           expect(response).to redirect_to edit_embargo_path(a_work)
         end
       end
@@ -71,7 +70,8 @@ describe EmbargoesController do
         let(:release_date) { Date.today - 2 }
 
         it 'deactivates embargo, update the visibility and redirect' do
-          expect(a_work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          expect(actor).to receive(:destroy)
+          get :destroy, id: a_work
           expect(response).to redirect_to confirm_curation_concerns_permission_path(a_work)
         end
       end


### PR DESCRIPTION
As embargos are just updated, not actually removed, they need to be
saved when they are changed.  Added an EmbargoActor to encapsulate that
functionality. Fixes #338