### PR TITLE
Create derivatives from the original

### DIFF
--- a/curation_concerns-models/app/jobs/characterize_job.rb
+++ b/curation_concerns-models/app/jobs/characterize_job.rb
@@ -1,10 +1,12 @@
 class CharacterizeJob < ActiveFedoraIdBasedJob
   queue_as :characterize
 
-  def perform(id)
+  # @param [String] id
+  # @param [String] filename a local filepath of whicih to characterize. By using this, we don't have to pull a copy out of fedora.
+  def perform(id, filename)
     @id = id
-    CurationConcerns::CharacterizationService.run(generic_file)
+    CurationConcerns::CharacterizationService.run(generic_file, filename)
     generic_file.save
-    CreateDerivativesJob.perform_later(generic_file.id)
+    CreateDerivativesJob.perform_later(generic_file.id, filename)
   end
 end

--- a/curation_concerns-models/app/jobs/create_derivatives_job.rb
+++ b/curation_concerns-models/app/jobs/create_derivatives_job.rb
@@ -1,12 +1,10 @@
 class CreateDerivativesJob < ActiveFedoraIdBasedJob
   queue_as :derivatives
 
-  def perform(id)
+  def perform(id, file_name)
     @id = id
-    return unless generic_file.original_file.has_content?
-    return unless CurationConcerns.config.enable_ffmpeg if generic_file.video?
+    return if generic_file.video? && !CurationConcerns.config.enable_ffmpeg
 
-    generic_file.create_derivatives
-    generic_file.save
+    generic_file.create_derivatives(file_name)
   end
 end

--- a/curation_concerns-models/app/jobs/ingest_file_job.rb
+++ b/curation_concerns-models/app/jobs/ingest_file_job.rb
@@ -1,0 +1,18 @@
+class IngestFileJob < ActiveJob::Base
+  queue_as :ingest
+
+  def perform(generic_file_id, filename, mime_type, user_key)
+    generic_file = GenericFile.find(generic_file_id)
+    file = Hydra::Derivatives::IoDecorator.new(File.open(filename, "rb"))
+    file.mime_type = mime_type
+    file.original_name = File.basename(filename)
+
+    # Tell UploadFileToGenericFile service to skip versioning because versions will be minted by VersionCommitter (called by save_characterize_and_record_committer) when necessary
+    Hydra::Works::UploadFileToGenericFile.call(generic_file, file, versioning: false)
+    generic_file.save!
+    CurationConcerns::VersioningService.create(generic_file.original_file, user_key)
+
+    return unless CurationConcerns.config.respond_to?(:after_create_content)
+    CurationConcerns.config.after_create_content.call(generic_file, user_key)
+  end
+end

--- a/curation_concerns-models/app/jobs/ingest_local_file_job.rb
+++ b/curation_concerns-models/app/jobs/ingest_local_file_job.rb
@@ -1,7 +1,7 @@
 class IngestLocalFileJob < ActiveJob::Base
   attr_accessor :directory, :filename, :user_key, :generic_file_id
 
-  queue_as :ingest
+  queue_as :ingest_local
 
   def perform(generic_file_id, directory, filename, user_key)
     @generic_file_id = generic_file_id

--- a/curation_concerns-models/app/models/concerns/curation_concerns/generic_file/derivatives.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/generic_file/derivatives.rb
@@ -4,17 +4,46 @@ module CurationConcerns
       extend ActiveSupport::Concern
 
       included do
+        Hydra::Derivatives.source_file_service = CurationConcerns::LocalFileService
         Hydra::Derivatives.output_file_service = CurationConcerns::PersistDerivatives
+      end
 
-        makes_derivatives do |obj|
-          case obj.original_file.mime_type
-          when *audio_mime_types
-            obj.transform_file :original_file, { mp3: { format: 'mp3' }, ogg: { format: 'ogg' } }, processor: :audio
-          when *video_mime_types
-            obj.transform_file :original_file, { webm: { format: 'webm' }, mp4: { format: 'mp4' } }, processor: :video
-          end
+      # This completely overrides the version in Hydra::Works so that we
+      # read and write to a local file. It's important that characterization runs
+      # before derivatives so that we have a credible mime_type field to work with.
+      def create_derivatives(filename)
+        case mime_type
+        when *self.class.pdf_mime_types
+          Hydra::Derivatives::PdfDerivatives.create(filename,
+                                                    outputs: [{ label: :thumbnail, format: 'jpg', size: '338x493', url: derivative_url('thumbnail') }])
+        when *self.class.office_document_mime_types
+          Hydra::Derivatives::DocumentDerivatives.create(filename,
+                                                         outputs: [{ label: :thumbnail, format: 'jpg',
+                                                                     size: '200x150>',
+                                                                     url: derivative_url('thumbnail') }])
+        when *self.class.audio_mime_types
+          Hydra::Derivatives::AudioDerivatives.create(filename,
+                                                      outputs: [{ label: 'mp3', format: 'mp3', url: derivative_url('mp3') },
+                                                                { label: 'ogg', format: 'ogg', url: derivative_url('ogg') }])
+        when *self.class.video_mime_types
+          Hydra::Derivatives::VideoDerivatives.create(filename,
+                                                      outputs: [{ label: :thumbnail, format: 'jpg', url: derivative_url('thumbnail') },
+                                                                { label: 'webm', format: 'webm', url: derivative_url('webm') },
+                                                                { label: 'mp4', format: 'mp4', url: derivative_url('mp4') }])
+        when *self.class.image_mime_types
+          Hydra::Derivatives::ImageDerivatives.create(filename,
+                                                      outputs: [{ label: :thumbnail, format: 'jpg', size: '200x150>', url: derivative_url('thumbnail') }])
         end
       end
+
+      private
+
+        # The destination_name parameter has to match up with the file parameter
+        # passed to the DownloadsController
+        def derivative_url(destination_name)
+          path = DerivativePath.derivative_path_for_reference(self, destination_name)
+          URI("file://#{path}").to_s
+        end
     end
   end
 end

--- a/curation_concerns-models/app/services/curation_concerns/characterization_service.rb
+++ b/curation_concerns-models/app/services/curation_concerns/characterization_service.rb
@@ -2,21 +2,26 @@ module CurationConcerns
   # Run FITS to gather technical metadata about the content and the full text.
   # Store this extracted metadata in the characterization datastream.
   class CharacterizationService
-    attr_reader :generic_file
+    attr_reader :generic_file, :file_path
 
-    def self.run(generic_file)
-      new(generic_file).characterize
+    # @param [GenericFile] generic_file
+    # @param [String] file_path path to the file on disk
+    def self.run(generic_file, file_path)
+      new(generic_file, file_path).characterize
     end
 
-    def initialize(generic_file)
+    # @param [GenericFile] generic_file
+    # @param [String] file_path path to the file on disk
+    def initialize(generic_file, file_path)
       @generic_file = generic_file
+      @file_path = file_path
     end
 
     ## Extract the metadata from the content datastream and record it in the characterization datastream
     def characterize
       store_metadata(extract_metadata)
       store_fulltext(extract_fulltext)
-      generic_file.filename = original_file.original_name
+      generic_file.filename = File.basename(file_path)
     end
 
     protected
@@ -28,7 +33,7 @@ module CurationConcerns
       end
 
       def extract_fulltext
-        Hydra::Works::FullTextExtractionService.run(generic_file)
+        Hydra::Works::FullTextExtractionService.run(generic_file, file_path)
       end
 
       def store_metadata(metadata)
@@ -41,8 +46,8 @@ module CurationConcerns
       end
 
       def extract_metadata
-        return unless original_file.has_content?
-        Hydra::FileCharacterization.characterize(original_file.content, original_file.original_name, :fits) do |config|
+        return unless File.exist?(file_path)
+        Hydra::FileCharacterization.characterize(File.open(file_path).read, File.basename(file_path), :fits) do |config|
           config[:fits] = Hydra::Derivatives.fits_path
         end
       end

--- a/curation_concerns-models/app/services/curation_concerns/local_file_service.rb
+++ b/curation_concerns-models/app/services/curation_concerns/local_file_service.rb
@@ -1,0 +1,10 @@
+module CurationConcerns
+  class LocalFileService
+    # @param [String] file_name path to the file
+    # @param [Hash] _options
+    # @yield [File] opens the file and yields it to the block
+    def self.call(file_name, _options)
+      yield File.open(file_name)
+    end
+  end
+end

--- a/curation_concerns-models/app/services/curation_concerns/versioning_service.rb
+++ b/curation_concerns-models/app/services/curation_concerns/versioning_service.rb
@@ -2,7 +2,7 @@ module CurationConcerns
   class VersioningService
     # Make a version and record the version committer
     # @param [ActiveFedora::File] content
-    # @param [User] user
+    # @param [User, String] user
     def self.create(content, user = nil)
       content.create_version
       record_committer(content, user) if user
@@ -15,11 +15,12 @@ module CurationConcerns
 
     # Record the version committer of the last version
     # @param [ActiveFedora::File] content
-    # @param [User] user
-    def self.record_committer(content, user)
+    # @param [User, String] user_key
+    def self.record_committer(content, user_key)
+      user_key = user_key.user_key if user_key.respond_to?(:user_key)
       version = latest_version_of(content)
       return if version.nil?
-      VersionCommitter.create(version_id: version.uri, committer_login: user.user_key)
+      VersionCommitter.create(version_id: version.uri, committer_login: user_key)
     end
   end
 end

--- a/curation_concerns-models/lib/curation_concerns/configuration.rb
+++ b/curation_concerns-models/lib/curation_concerns/configuration.rb
@@ -33,6 +33,12 @@ module CurationConcerns
       @derivatives_path ||= File.join(Rails.root, 'tmp', 'derivatives')
     end
 
+    # Path on the local file system where originals will be staged before being ingested into Fedora.
+    attr_writer :working_path
+    def working_path
+      @working_path ||= File.join(Rails.root, 'tmp', 'uploads')
+    end
+
     attr_writer :enable_ffmpeg
     def enable_ffmpeg
       return @enable_ffmpeg unless @enable_ffmpeg.nil?

--- a/spec/actors/curation_concerns/generic_file_actor_spec.rb
+++ b/spec/actors/curation_concerns/generic_file_actor_spec.rb
@@ -19,7 +19,8 @@ describe CurationConcerns::GenericFileActor do
     end
 
     before do
-      allow(actor).to receive(:save_characterize_and_record_committer).and_return('true')
+      expect(CharacterizeJob).to receive(:perform_later)
+      expect(IngestFileJob).to receive(:perform_later).with(generic_file.id, /world\.png$/, 'image/png', user.user_key)
       allow(actor).to receive(:acquire_lock_for).and_yield
       actor.create_metadata(upload_set_id, work_id)
       actor.create_content(uploaded_file)
@@ -74,10 +75,10 @@ describe CurationConcerns::GenericFileActor do
   end
 
   describe '#create_content' do
-    it 'uses the provided mime_type' do
+    it 'calls ingest file job' do
       expect(CharacterizeJob).to receive(:perform_later)
+      expect(IngestFileJob).to receive(:perform_later).with(generic_file.id, /world\.png$/, 'image/png', user.user_key)
       actor.create_content(uploaded_file)
-      expect(generic_file.original_file.mime_type).to eq 'image/png'
     end
 
     context 'when generic_file.title is empty and generic_file.label is not' do
@@ -97,48 +98,11 @@ describe CurationConcerns::GenericFileActor do
       it { is_expected.to eql [short_name] }
     end
 
-    context 'with two existing versions from different users' do
-      let(:file1)       { 'world.png' }
-      let(:file2)       { 'small_file.txt' }
-      let(:actor1)      { described_class.new(generic_file, user) }
-      let(:actor2)      { described_class.new(generic_file, second_user) }
-
-      let(:second_user) { create(:user) }
-      let(:versions) { generic_file.original_file.versions }
-
-      before do
-        allow(CharacterizeJob).to receive(:perform_later)
-        actor1.create_content(fixture_file_upload(file1))
-        actor2.create_content(fixture_file_upload(file2))
-      end
-
-      it 'has two versions' do
-        expect(versions.all.count).to eq 2
-      end
-
-      it 'has the current version' do
-        expect(CurationConcerns::VersioningService.latest_version_of(generic_file.original_file).label).to eq 'version2'
-        expect(generic_file.original_file.content).to eq fixture_file_upload(file2).read
-        expect(generic_file.original_file.mime_type).to eq 'text/plain'
-        expect(generic_file.original_file.original_name).to eq file2
-      end
-
-      it "uses the first version for the object's title and label" do
-        expect(generic_file.label).to eql(file1)
-        expect(generic_file.title.first).to eql(file1)
-      end
-
-      it 'notes the user for each version' do
-        expect(VersionCommitter.where(version_id: versions.first.uri).pluck(:committer_login)).to eq [user.user_key]
-        expect(VersionCommitter.where(version_id: versions.last.uri).pluck(:committer_login)).to eq [second_user.user_key]
-      end
-    end
-
     context 'when a label is already specified' do
+      let(:file)     { 'world.png' }
       let(:label)    { 'test_file.png' }
-      let(:new_file) { 'foo.jpg' }
       let(:generic_file_with_label) do
-        GenericFile.new.tap do |f|
+        GenericFile.new do |f|
           f.apply_depositor_metadata(user.user_key)
           f.label = label
         end
@@ -146,12 +110,12 @@ describe CurationConcerns::GenericFileActor do
       let(:actor) { described_class.new(generic_file_with_label, user) }
 
       before do
-        allow(actor).to receive(:save_characterize_and_record_committer).and_return('true')
-        allow(Hydra::Works::UploadFileToGenericFile).to receive(:call)
-        actor.create_content(Tempfile.new(new_file))
+        allow(IngestFileJob).to receive(:perform_later)
+        allow(CharacterizeJob).to receive(:perform_later)
+        actor.create_content(fixture_file_upload(file))
       end
 
-      it "will retain the object's original label" do
+      it "retains the object's original label" do
         expect(generic_file_with_label.label).to eql(label)
       end
     end

--- a/spec/actors/curation_concerns/work_actor_spec.rb
+++ b/spec/actors/curation_concerns/work_actor_spec.rb
@@ -109,7 +109,7 @@ describe CurationConcerns::GenericWorkActor do
 
       context 'with a file' do
         let(:attributes) do
-          FactoryGirl.attributes_for(:generic_work, visibility: visibility).tap do|a|
+          FactoryGirl.attributes_for(:generic_work, visibility: visibility).tap do |a|
             a[:files] = file
           end
         end
@@ -131,7 +131,7 @@ describe CurationConcerns::GenericWorkActor do
             # Sanity test to make sure the file we uploaded is stored and has same permission as parent.
             generic_file = curation_concern.generic_files.first
             file.rewind
-            expect(generic_file.original_file.content).to eq file.read
+            expect(generic_file.reload.original_file.content).to eq file.read
 
             expect(curation_concern).to be_authenticated_only_access
             expect(generic_file).to be_authenticated_only_access

--- a/spec/controllers/curation_concerns/generic_files_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_files_controller_spec.rb
@@ -158,7 +158,7 @@ describe CurationConcerns::GenericFilesController do
 
       context 'updating file content' do
         it 'is successful' do
-          expect(CharacterizeJob).to receive(:perform_later).with(generic_file.id)
+          expect(CharacterizeJob).to receive(:perform_later).with(generic_file.id, kind_of(String))
           post :update, id: generic_file, generic_file: { files: [file] }
           expect(response).to redirect_to main_app.curation_concerns_generic_file_path(generic_file)
           skip 'pending hydra-works#89'
@@ -176,6 +176,7 @@ describe CurationConcerns::GenericFilesController do
           Hydra::Works::AddFileToGenericFile.call(generic_file, File.open(fixture_file_path('curation_concerns_generic_stub.txt')), :original_file)
         end
 
+        # TODO: This test should move into the GenericFileActor spec and just ensure the actor is called.
         it 'is successful' do
           expect(generic_file.latest_content_version.label).to eq('version2')
           expect(generic_file.original_file.content).to eq("This is a test fixture for curation_concerns: <%= @id %>.\n")

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -45,10 +45,10 @@ describe DownloadsController do
         context "that is persisted" do
           let(:file) { File.open(fixture_file_path('world.png'), 'rb') }
 
-          let(:content) { file.rewind; file.read }
+          let(:content) { file.read }
 
           before do
-            CurationConcerns::PersistDerivatives.call(generic_file, file, 'thumbnail')
+            allow(CurationConcerns::DerivativePath).to receive(:derivative_path_for_reference).and_return(fixture_file_path('world.png'))
           end
 
           it 'sends requested file content' do

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -3,15 +3,16 @@ require 'spec_helper'
 describe CharacterizeJob do
   let(:generic_file) { GenericFile.new(id: generic_file_id) }
   let(:generic_file_id) { 'abc123' }
+  let(:filename) { double }
 
   before do
     allow(ActiveFedora::Base).to receive(:find).with(generic_file_id).and_return(generic_file)
   end
 
-  it 'runs CurationConcerns::CharacterizationService that spawns a CreateDerivativesJob' do
-    expect(CurationConcerns::CharacterizationService).to receive(:run).with(generic_file)
+  it 'runs CurationConcerns::CharacterizationService and creates a CreateDerivativesJob' do
+    expect(CurationConcerns::CharacterizationService).to receive(:run).with(generic_file, filename)
     expect(generic_file).to receive(:save)
-    expect(CreateDerivativesJob).to receive(:perform_later).with(generic_file_id)
-    described_class.perform_now generic_file_id
+    expect(CreateDerivativesJob).to receive(:perform_later).with(generic_file_id, filename)
+    described_class.perform_now generic_file_id, filename
   end
 end

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -5,17 +5,20 @@ describe CurationConcerns::CreateDerivativesJob do
     @ffmpeg_enabled = CurationConcerns.config.enable_ffmpeg
     CurationConcerns.config.enable_ffmpeg = true
     allow(ActiveFedora::Base).to receive(:find).with('123').and_return(generic_file)
-    allow(generic_file).to receive(:original_file).and_return(double('orignal_file', has_content?: true))
+    allow(generic_file).to receive(:mime_type).and_return('audio/x-wav')
+    allow(generic_file).to receive(:id).and_return('123')
   end
+
   let(:generic_file) { GenericFile.new }
 
   after do
     CurationConcerns.config.enable_ffmpeg = @ffmpeg_enabled
   end
 
-  it 'calls create_derivatives and save on a generic_file' do
-    expect(generic_file).to receive(:create_derivatives)
-    expect(generic_file).to receive(:save)
-    CreateDerivativesJob.perform_now('123')
+  context "with a file name" do
+    it 'calls create_derivatives and save on a generic_file' do
+      expect(Hydra::Derivatives::AudioDerivatives).to receive(:create)
+      CreateDerivativesJob.perform_now('123', 'spec/fixtures/piano_note.wav')
+    end
   end
 end

--- a/spec/jobs/ingest_file_job_spec.rb
+++ b/spec/jobs/ingest_file_job_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe IngestFileJob do
+  let(:generic_file) { create(:generic_file) }
+  let(:filename) { fixture_file_path('/world.png') }
+
+  it 'uses the provided mime_type' do
+    described_class.perform_now(generic_file.id, filename, 'image/png', 'bob')
+    expect(generic_file.reload.original_file.mime_type).to eq 'image/png'
+  end
+
+  context 'with two existing versions from different users' do
+    let(:file1)       { fixture_file_path 'world.png' }
+    let(:file2)       { fixture_file_path 'small_file.txt' }
+    let(:actor1)      { described_class.new(generic_file, user) }
+    let(:actor2)      { described_class.new(generic_file, second_user) }
+
+    let(:second_user) { create(:user) }
+    let(:versions) { generic_file.reload.original_file.versions }
+
+    before do
+      described_class.perform_now(generic_file.id, file1, 'image/png', 'bob')
+      described_class.perform_now(generic_file.id, file2, 'text/plain', 'bess')
+    end
+
+    it 'has two versions' do
+      expect(versions.all.count).to eq 2
+
+      # the current version
+      expect(CurationConcerns::VersioningService.latest_version_of(generic_file.reload.original_file).label).to eq 'version2'
+      expect(generic_file.original_file.content).to eq File.open(file2).read
+      expect(generic_file.original_file.mime_type).to eq 'text/plain'
+      expect(generic_file.original_file.original_name).to eq 'small_file.txt'
+
+      # the user for each version
+      expect(VersionCommitter.where(version_id: versions.first.uri).pluck(:committer_login)).to eq ['bob']
+      expect(VersionCommitter.where(version_id: versions.last.uri).pluck(:committer_login)).to eq ['bess']
+    end
+  end
+end

--- a/spec/models/curation_concerns/generic_file/derivatives_spec.rb
+++ b/spec/models/curation_concerns/generic_file/derivatives_spec.rb
@@ -4,10 +4,7 @@ describe CurationConcerns::GenericFile do
   let(:generic_file) { GenericFile.create { |gf| gf.apply_depositor_metadata('jcoyne@example.com') } }
 
   before do
-    file = File.open(File.join(fixture_path, file_name), 'r')
-    Hydra::Works::UploadFileToGenericFile.call(generic_file, file)
-    allow_any_instance_of(Hydra::Works::GenericFile::Base).to receive(:mime_type).and_return(mime_type)
-    generic_file.save!
+    allow(generic_file).to receive(:mime_type).and_return(mime_type)
   end
 
   after do
@@ -17,41 +14,48 @@ describe CurationConcerns::GenericFile do
 
   describe 'image derivative' do
     let(:mime_type) { 'image/jp2' }
-    let(:file_name) { 'image.jp2' }
+    let(:file_name) { File.join(fixture_path, 'image.jp2') }
     it 'only makes one thumbnail' do
-      expect(generic_file).to receive(:transform_file).once
-      generic_file.create_derivatives
+      expect_any_instance_of(Hydra::Derivatives::Image).to receive(:process).once
+      generic_file.create_derivatives(file_name)
     end
   end
 
   describe 'pdf derivative' do
     let(:mime_type) { 'application/pdf' }
-    let(:file_name) { 'test.pdf' }
+    let(:file_name) { File.join(fixture_path, 'test.pdf') }
     it 'only makes one thumbnail' do
-      expect(generic_file).to receive(:transform_file).once
-      generic_file.create_derivatives
+      expect_any_instance_of(Hydra::Derivatives::Image).to receive(:process).once
+      generic_file.create_derivatives(file_name)
     end
   end
 
   describe 'office derivative' do
     let(:mime_type) { 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
-    let(:file_name) { 'charter.docx' }
+    let(:file_name) { File.join(fixture_path, 'charter.docx') }
     it 'only makes one thumbnail' do
-      expect(generic_file).to receive(:transform_file).once
-      generic_file.create_derivatives
+      expect_any_instance_of(Hydra::Derivatives::Document).to receive(:process).once
+      generic_file.create_derivatives(file_name)
     end
   end
 
   describe 'audiovisual transcoding', unless: $in_travis do
+    before do
+      # stub the name service so it's easer to find where the file will be
+      allow(CurationConcerns::DerivativePath).to receive(:derivative_path_for_reference) do |object, key|
+        "#{Rails.root}/tmp/derivatives/#{object.id}/#{key}.#{key}"
+      end
+    end
+
     context 'with a video (.avi) file' do
       let(:mime_type) { 'video/avi' }
-      let(:file_name) { 'countdown.avi' }
+      let(:file_name) { File.join(fixture_path, 'countdown.avi') }
 
       it 'transcodes to webm and mp4' do
         new_webm = "#{Rails.root}/tmp/derivatives/#{generic_file.id}/webm.webm"
         new_mp4 = "#{Rails.root}/tmp/derivatives/#{generic_file.id}/mp4.mp4"
         expect {
-          generic_file.create_derivatives
+          generic_file.create_derivatives(file_name)
         }.to change { File.exist?(new_webm) }
           .from(false).to(true)
           .and change { File.exist?(new_mp4) }
@@ -61,51 +65,17 @@ describe CurationConcerns::GenericFile do
 
     context 'with an audio (.wav) file' do
       let(:mime_type) { 'audio/wav' }
-      let(:file_name) { 'piano_note.wav' }
+      let(:file_name) { File.join(fixture_path, 'piano_note.wav') }
 
       it 'transcodes to mp3 and ogg' do
         new_mp3 = "#{Rails.root}/tmp/derivatives/#{generic_file.id}/mp3.mp3"
         new_ogg = "#{Rails.root}/tmp/derivatives/#{generic_file.id}/ogg.ogg"
         expect {
-          generic_file.create_derivatives
+          generic_file.create_derivatives(file_name)
         }.to change { File.exist?(new_mp3) }
           .from(false).to(true)
           .and change { File.exist?(new_ogg) }
           .from(false).to(true)
-      end
-    end
-
-    context 'with an mp3 file' do
-      let(:mime_type) { 'audio/mpeg' }
-      let(:file_name) { 'test5.mp3' }
-
-      xit 'should copy the content to the mp3 datastream and transcode to ogg' do
-        generic_file.create_derivatives
-        derivative = generic_file.mp3
-
-        expect(derivative.size).to eq(generic_file.original_file.size)
-        expect(derivative.mime_type).to eq('audio/mpeg')
-        derivative2 = generic_file.ogg
-        expect(derivative2.content).not_to be_nil
-        expect(derivative2.mime_type).to eq('audio/ogg')
-      end
-    end
-
-    context 'with an ogg file' do
-      let(:mime_type) { 'audio/ogg' }
-      let(:file_name) { 'Example.ogg' }
-
-      xit 'should copy the content to the ogg datastream and transcode to mp3' do
-        generic_file.create_derivatives
-        derivative = generic_file.mp3
-        expect(derivative).not_to be_nil
-        expect(derivative.content).not_to be_nil
-        expect(derivative.mime_type).to eq('audio/mpeg')
-
-        derivative2 = generic_file.ogg
-        expect(derivative2).not_to be_nil
-        expect(derivative2.size).to eq(generic_file.original_file.size)
-        expect(derivative2.mime_type).to eq('audio/ogg')
       end
     end
   end

--- a/spec/models/fits_datastream_spec.rb
+++ b/spec/models/fits_datastream_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 describe FitsDatastream, type: :model, unless: $in_travis do
   describe 'image' do
     before(:all) do
+      @file_path = fixture_file_path('world.png')
       @file = GenericFile.create { |gf| gf.apply_depositor_metadata('blah') }
-      Hydra::Works::AddFileToGenericFile.call(@file, File.open(fixture_file_path('world.png')), :original_file)
-      CurationConcerns::CharacterizationService.run(@file)
+      Hydra::Works::AddFileToGenericFile.call(@file, File.open(@file_path), :original_file)
+      CurationConcerns::CharacterizationService.run(@file, @file_path)
     end
     it 'has a format label' do
       expect(@file.format_label).to eq ['Portable Network Graphics']
@@ -43,9 +44,10 @@ describe FitsDatastream, type: :model, unless: $in_travis do
 
   describe 'video' do
     before(:all) do
+      @file_path = fixture_file_path('sample_mpeg4.mp4')
       @file = GenericFile.create { |gf| gf.apply_depositor_metadata('blah') }
-      Hydra::Works::AddFileToGenericFile.call(@file, File.open(fixture_file_path('sample_mpeg4.mp4')), :original_file)
-      CurationConcerns::CharacterizationService.run(@file)
+      Hydra::Works::AddFileToGenericFile.call(@file, File.open(@file_path), :original_file)
+      CurationConcerns::CharacterizationService.run(@file, @file_path)
     end
     it 'has a format label' do
       expect(@file.format_label).to eq ['ISO Media, MPEG v4 system, version 2']
@@ -84,11 +86,12 @@ describe FitsDatastream, type: :model, unless: $in_travis do
   end
 
   describe 'pdf' do
+    let(:file_path) { fixture_file_path('test4.pdf') }
     before do
       @myfile = GenericFile.create { |gf| gf.apply_depositor_metadata('blah') }
-      Hydra::Works::AddFileToGenericFile.call(@myfile, File.open(fixture_file_path('test4.pdf')), :original_file)
+      Hydra::Works::AddFileToGenericFile.call(@myfile, File.open(file_path), :original_file)
       # characterize method saves
-      CurationConcerns::CharacterizationService.run(@myfile)
+      CurationConcerns::CharacterizationService.run(@myfile, file_path)
     end
 
     it 'returns expected results after a save' do
@@ -111,11 +114,12 @@ describe FitsDatastream, type: :model, unless: $in_travis do
   end
 
   describe 'm4a' do
+    let(:file_path) { fixture_file_path('spoken-text.m4a') }
     before do
       @myfile = GenericFile.create { |gf| gf.apply_depositor_metadata('blah') }
-      Hydra::Works::AddFileToGenericFile.call(@myfile, File.open(fixture_file_path('spoken-text.m4a')), :original_file)
+      Hydra::Works::AddFileToGenericFile.call(@myfile, File.open(file_path), :original_file)
       # characterize method saves
-      CurationConcerns::CharacterizationService.run(@myfile)
+      CurationConcerns::CharacterizationService.run(@myfile, file_path)
     end
 
     it 'returns expected content for full text' do

--- a/spec/services/characterization_service_spec.rb
+++ b/spec/services/characterization_service_spec.rb
@@ -5,10 +5,11 @@ describe CurationConcerns::CharacterizationService do
 
   describe '#run' do
     let(:service_instance) { double }
+    let(:file_name) { double }
     it 'creates an instance of the service and calls .characterize on it' do
-      expect(described_class).to receive(:new).with(generic_file).and_return(service_instance)
+      expect(described_class).to receive(:new).with(generic_file, file_name).and_return(service_instance)
       expect(service_instance).to receive(:characterize)
-      described_class.run(generic_file)
+      described_class.run(generic_file, file_name)
     end
   end
 
@@ -31,13 +32,12 @@ describe CurationConcerns::CharacterizationService do
   </metadata>
 </fits>'
     }
-    subject { described_class.new(generic_file) }
-    before do
-      Hydra::Works::UploadFileToGenericFile.call(generic_file, File.open(fixture_file_path('charter.docx')))
-    end
+
+    let(:file_name) { fixture_file_path('charter.docx') }
+    subject { described_class.new(generic_file, file_name) }
 
     it 'characterizes, extracts fulltext and stores the results' do
-      expect(Hydra::Works::FullTextExtractionService).to receive(:run).with(generic_file).and_return('The fulltext')
+      expect(Hydra::Works::FullTextExtractionService).to receive(:run).with(generic_file, file_name).and_return('The fulltext')
       expect(Hydra::FileCharacterization).to receive(:characterize).and_return(fits_xml)
 
       subject.characterize

--- a/spec/services/persist_derivatives_spec.rb
+++ b/spec/services/persist_derivatives_spec.rb
@@ -6,16 +6,16 @@ describe CurationConcerns::PersistDerivatives do
   end
 
   describe '.output_file' do
-    subject { described_class.output_file(object, destination_name, &block) }
+    subject { described_class.output_file(directives, &block) }
 
-    let(:object) { double(id: '1234567') }
+    let(:directives) { { url: "file:/tmp/12/34/56/7-thumbnail.jpeg" } }
     let(:destination_name) { 'thumbnail' }
 
     let(:block) { lambda { true } }
 
     it 'yields to the file' do
-      expect(FileUtils).to receive(:mkdir_p).with('tmp/12/34/56')
-      expect(File).to receive(:open).with('tmp/12/34/56/7-thumbnail.jpeg', 'wb') do |*_, &blk|
+      expect(FileUtils).to receive(:mkdir_p).with('/tmp/12/34/56')
+      expect(File).to receive(:open).with('/tmp/12/34/56/7-thumbnail.jpeg', 'wb') do |*_, &blk|
         expect(blk).to be(block)
       end
       subject

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,1 +1,3 @@
 # placeholder to use for pinning against specific gem commit references
+gem 'hydra-works', github: 'projecthydra-labs/hydra-works', ref: '5e640f7'
+gem 'hydra-derivatives', github: 'projecthydra/hydra-derivatives', branch: 'transcode_local_file'


### PR DESCRIPTION
Not from a copy retrieved from the repository
This makes importing faster as less network traffic is required.