### PR TITLE
Remove copy visibility from the actors

### DIFF
--- a/curation_concerns-models/app/actors/concerns/curation_concerns/manages_embargoes_actor.rb
+++ b/curation_concerns-models/app/actors/concerns/curation_concerns/manages_embargoes_actor.rb
@@ -9,11 +9,11 @@ module CurationConcerns
   #     include Worthwile::ManagesEmbargoesActor
   #
   #     def create
-  #       interpret_visibility && super && copy_visibility
+  #       interpret_visibility && super
   #     end
   #
   #     def update
-  #       interpret_visibility && super && copy_visibility
+  #       interpret_visibility && super
   #     end
   #  end
   #
@@ -44,7 +44,6 @@ module CurationConcerns
           if curation_concern.embargo
             curation_concern.embargo.save # See https://github.com/projecthydra/hydra-head/issues/226
           end
-          @needs_to_copy_visibility = true
           should_continue = true
         end
       else
@@ -73,7 +72,6 @@ module CurationConcerns
           if curation_concern.lease
             curation_concern.lease.save # See https://github.com/projecthydra/hydra-head/issues/226
           end
-          @needs_to_copy_visibility = true
           attributes.delete(:visibility)
           should_continue = true
         end
@@ -88,11 +86,6 @@ module CurationConcerns
       attributes.delete(:visibility_after_lease)
 
       should_continue
-    end
-
-    def copy_visibility
-      VisibilityCopyJob.perform_later(curation_concern.id) if @needs_to_copy_visibility
-      true
     end
   end
 end

--- a/curation_concerns-models/app/actors/curation_concerns/work_actor_behavior.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/work_actor_behavior.rb
@@ -7,12 +7,12 @@ module CurationConcerns::WorkActorBehavior
     files && attributes.delete(:files)
     self.raw_attributes = attributes.dup
     # Files must be attached before saving in order to persist their relationship to the work
-    assign_pid && interpret_visibility && attach_files && super && assign_representative && copy_visibility
+    assign_pid && interpret_visibility && attach_files && super && assign_representative
   end
 
   def update
     add_to_collections(attributes.delete(:collection_ids)) &&
-      interpret_visibility && super && attach_files && copy_visibility
+      interpret_visibility && super && attach_files
   end
 
   delegate :visibility_changed?, to: :curation_concern


### PR DESCRIPTION
Copying visibility is controlled by the controller after the user
indicates they want visibility copied. Fixes #353