### PR TITLE
Lease and Embargo pages draw out of Solr

### DIFF
--- a/app/presenters/curation_concerns/embargo_presenter.rb
+++ b/app/presenters/curation_concerns/embargo_presenter.rb
@@ -1,0 +1,26 @@
+module CurationConcerns
+  # Presents embargoed objects
+  class EmbargoPresenter
+    include ModelProxy
+    attr_accessor :solr_document
+
+    delegate :human_readable_type, :visibility, :to_s, to: :solr_document
+
+    # @param [SolrDocument] solr_document
+    def initialize(solr_document)
+      @solr_document = solr_document
+    end
+
+    def embargo_release_date
+      Date.parse(solr_document.embargo_release_date).to_formatted_s(:rfc822)
+    end
+
+    def visibility_after_embargo
+      solr_document.fetch('visibility_after_embargo_ssim', []).first
+    end
+
+    def embargo_history
+      solr_document['embargo_history_ssim']
+    end
+  end
+end

--- a/app/presenters/curation_concerns/lease_presenter.rb
+++ b/app/presenters/curation_concerns/lease_presenter.rb
@@ -1,0 +1,30 @@
+module CurationConcerns
+  # Presents leased objects
+  class LeasePresenter
+    include ModelProxy
+    attr_accessor :solr_document
+
+    delegate :human_readable_type, :visibility, :to_s, to: :solr_document
+
+    # @param [SolrDocument] solr_document
+    def initialize(solr_document)
+      @solr_document = solr_document
+    end
+
+    def lease_expiration_date
+      if solr_document.lease_expiration_date
+        Date.parse(solr_document.lease_expiration_date).to_formatted_s(:rfc822)
+      else
+        solr_document.keys
+      end
+    end
+
+    def visibility_after_lease
+      solr_document.fetch('visibility_after_lease_ssim', []).first
+    end
+
+    def lease_history
+      solr_document['lease_history_ssim']
+    end
+  end
+end

--- a/app/search_builders/curation_concerns/deactivated_embargo_search_builder.rb
+++ b/app/search_builders/curation_concerns/deactivated_embargo_search_builder.rb
@@ -1,0 +1,10 @@
+module CurationConcerns
+  class DeactivatedEmbargoSearchBuilder < EmbargoSearchBuilder
+    self.default_processor_chain += [:with_deactivated_embargos]
+
+    def with_deactivated_embargos(solr_params)
+      solr_params[:fq] ||= []
+      solr_params[:fq] = 'embargo_history_ssim:*'
+    end
+  end
+end

--- a/app/search_builders/curation_concerns/deactivated_lease_search_builder.rb
+++ b/app/search_builders/curation_concerns/deactivated_lease_search_builder.rb
@@ -1,0 +1,10 @@
+module CurationConcerns
+  class DeactivatedLeaseSearchBuilder < LeaseSearchBuilder
+    self.default_processor_chain += [:with_deactivated_leases]
+
+    def with_deactivated_leases(solr_params)
+      solr_params[:fq] ||= []
+      solr_params[:fq] = 'lease_history_ssim:*'
+    end
+  end
+end

--- a/app/search_builders/curation_concerns/embargo_search_builder.rb
+++ b/app/search_builders/curation_concerns/embargo_search_builder.rb
@@ -1,0 +1,19 @@
+module CurationConcerns
+  # Finds embargoed objects
+  class EmbargoSearchBuilder < Blacklight::SearchBuilder
+    self.default_processor_chain = [:add_paging_to_solr, :only_active_embargoes]
+    def initialize(scope)
+      super(true, scope)
+    end
+
+    # TODO: add more complex pagination
+    def add_paging_to_solr(solr_params)
+      solr_params[:rows] = 1000
+    end
+
+    def only_active_embargoes(solr_params)
+      solr_params[:fq] ||= []
+      solr_params[:fq] = 'embargo_release_date_dtsi:*'
+    end
+  end
+end

--- a/app/search_builders/curation_concerns/expired_embargo_search_builder.rb
+++ b/app/search_builders/curation_concerns/expired_embargo_search_builder.rb
@@ -1,0 +1,11 @@
+module CurationConcerns
+  # Finds embargoed objects with release dates in the past
+  class ExpiredEmbargoSearchBuilder < EmbargoSearchBuilder
+    self.default_processor_chain += [:only_expired_embargoes]
+
+    def only_expired_embargoes(solr_params)
+      solr_params[:fq] ||= []
+      solr_params[:fq] = 'embargo_release_date_dtsi:[* TO NOW]'
+    end
+  end
+end

--- a/app/search_builders/curation_concerns/expired_lease_search_builder.rb
+++ b/app/search_builders/curation_concerns/expired_lease_search_builder.rb
@@ -1,0 +1,11 @@
+module CurationConcerns
+  # Finds embargoed objects with release dates in the past
+  class ExpiredLeaseSearchBuilder < LeaseSearchBuilder
+    self.default_processor_chain += [:only_expired_leases]
+
+    def only_expired_leases(solr_params)
+      solr_params[:fq] ||= []
+      solr_params[:fq] = 'lease_expiration_date_dtsi:[* TO NOW]'
+    end
+  end
+end

--- a/app/search_builders/curation_concerns/lease_search_builder.rb
+++ b/app/search_builders/curation_concerns/lease_search_builder.rb
@@ -1,0 +1,19 @@
+module CurationConcerns
+  # Finds objects under lease
+  class LeaseSearchBuilder < Blacklight::SearchBuilder
+    self.default_processor_chain = [:add_paging_to_solr, :only_active_leases]
+    def initialize(scope)
+      super(true, scope)
+    end
+
+    # TODO: add more complex pagination
+    def add_paging_to_solr(solr_params)
+      solr_params[:rows] = 1000
+    end
+
+    def only_active_leases(solr_params)
+      solr_params[:fq] ||= []
+      solr_params[:fq] = 'lease_expiration_date_dtsi:*'
+    end
+  end
+end

--- a/app/services/curation_concerns/embargo_service.rb
+++ b/app/services/curation_concerns/embargo_service.rb
@@ -1,5 +1,5 @@
 module CurationConcerns
-  module EmbargoService
+  class EmbargoService < RestrictionService
     class << self
       #
       # Methods for Querying Repository to find Embargoed Objects
@@ -7,20 +7,42 @@ module CurationConcerns
 
       # Returns all assets with embargo release date set to a date in the past
       def assets_with_expired_embargoes
-        ActiveFedora::Base.where('embargo_release_date_dtsi:[* TO NOW]')
+        builder = CurationConcerns::ExpiredEmbargoSearchBuilder.new(self)
+        presenters(builder)
       end
 
       # Returns all assets with embargo release date set
       #   (assumes that when lease visibility is applied to assets
       #    whose leases have expired, the lease expiration date will be removed from its metadata)
       def assets_under_embargo
-        ActiveFedora::Base.where('embargo_release_date_dtsi:*')
+        builder = CurationConcerns::EmbargoSearchBuilder.new(self)
+        presenters(builder)
       end
 
       # Returns all assets that have had embargoes deactivated in the past.
       def assets_with_deactivated_embargoes
-        ActiveFedora::Base.where('embargo_history_ssim:*')
+        builder = CurationConcerns::DeactivatedEmbargoSearchBuilder.new(self)
+        presenters(builder)
       end
+
+      private
+
+        def presenter_class
+          CurationConcerns::EmbargoPresenter
+        end
+
+        def presenters(builder)
+          response = repository.search(builder)
+          response.documents.map { |d| presenter_class.new(d) }
+        end
+
+        def repository
+          config.repository
+        end
+
+        def config
+          @config ||= ::CatalogController.new
+        end
     end
   end
 end

--- a/app/services/curation_concerns/lease_service.rb
+++ b/app/services/curation_concerns/lease_service.rb
@@ -1,22 +1,32 @@
 module CurationConcerns
-  module LeaseService
+  class LeaseService < RestrictionService
     class << self
       # Returns all assets with lease expiration date set to a date in the past
       def assets_with_expired_leases
-        ActiveFedora::Base.where('lease_expiration_date_dtsi:[* TO NOW]')
+        # ActiveFedora::Base.where('lease_expiration_date_dtsi:[* TO NOW]')
+        builder = CurationConcerns::ExpiredLeaseSearchBuilder.new(self)
+        presenters(builder)
       end
 
       # Returns all assets with lease expiration date set
       #   (assumes that when lease visibility is applied to assets
       #    whose leases have expired, the lease expiration date will be removed from its metadata)
       def assets_under_lease
-        ActiveFedora::Base.where('lease_expiration_date_dtsi:*')
+        builder = CurationConcerns::LeaseSearchBuilder.new(self)
+        presenters(builder)
       end
 
       # Returns all assets that have had embargoes deactivated in the past.
       def assets_with_deactivated_leases
-        ActiveFedora::Base.where('lease_history_ssim:*')
+        builder = CurationConcerns::DeactivatedLeaseSearchBuilder.new(self)
+        presenters(builder)
       end
+
+      private
+
+        def presenter_class
+          CurationConcerns::LeasePresenter
+        end
     end
   end
 end

--- a/app/services/curation_concerns/restriction_service.rb
+++ b/app/services/curation_concerns/restriction_service.rb
@@ -1,0 +1,24 @@
+module CurationConcerns
+  class RestrictionService
+    class << self
+      private
+
+        def presenter_class
+          raise "RestrictionService is an Abstract class and should be extended. Implement presenter_class in the subclass"
+        end
+
+        def presenters(builder)
+          response = repository.search(builder)
+          response.documents.map { |d| presenter_class.new(d) }
+        end
+
+        def repository
+          config.repository
+        end
+
+        def config
+          @config ||= ::CatalogController.new
+        end
+    end
+  end
+end

--- a/curation_concerns-models/app/models/concerns/curation_concerns/generic_file_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/generic_file_behavior.rb
@@ -15,6 +15,7 @@ module CurationConcerns
     include CurationConcerns::GenericFile::Indexing
     include CurationConcerns::GenericFile::BelongsToWorks
     include CurationConcerns::GenericFile::BelongsToUploadSets
+    include CurationConcerns::HumanReadableType
     include Hydra::AccessControls::Embargoable
 
     included do

--- a/curation_concerns-models/app/models/concerns/curation_concerns/solr_document_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/solr_document_behavior.rb
@@ -114,5 +114,19 @@ module CurationConcerns
     def mime_type
       self[Solrizer.solr_name('mime_type', :stored_sortable)]
     end
+
+    def read_groups
+      fetch('read_access_group_ssim', [])
+    end
+
+    def visibility
+      if read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      elsif read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      else
+        Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
+    end
   end
 end

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -369,7 +369,7 @@ describe GenericFile do
   end
 
   describe 'to_solr' do
-    let(:indexer) { double }
+    let(:indexer) { double(generate_solr_document: {}) }
     before do
       allow(CurationConcerns::GenericFileIndexingService).to receive(:new)
         .with(subject).and_return(indexer)
@@ -378,6 +378,10 @@ describe GenericFile do
     it 'calls the indexer' do
       expect(indexer).to receive(:generate_solr_document)
       subject.to_solr
+    end
+
+    it 'has human readable type' do
+      expect(subject.to_solr.fetch('human_readable_type_tesim')).to eq 'Generic File'
     end
   end
 

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -9,4 +9,23 @@ describe SolrDocument do
 
     it { is_expected.to eq '08/31/2015' }
   end
+
+  describe "visibility" do
+    subject { document.visibility }
+
+    context "when open" do
+      let(:attributes) { { 'read_access_group_ssim' => ['public'] } }
+      it { is_expected.to eq 'open' }
+    end
+
+    context "when authenticated" do
+      let(:attributes) { { 'read_access_group_ssim' => ['registered'] } }
+      it { is_expected.to eq 'authenticated' }
+    end
+
+    context "when restricted" do
+      let(:attributes) { {} }
+      it { is_expected.to eq 'restricted' }
+    end
+  end
 end

--- a/spec/presenters/embargo_presenter_spec.rb
+++ b/spec/presenters/embargo_presenter_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe CurationConcerns::EmbargoPresenter do
+  let(:document) { SolrDocument.new(attributes) }
+  let(:presenter) { described_class.new(document) }
+  let(:attributes) { {} }
+
+  describe "visibility" do
+    subject { presenter.visibility }
+
+    it { is_expected.to eq 'restricted' }
+  end
+
+  describe "to_s" do
+    let(:attributes) { { 'title_tesim' => ['Hey guys!'] } }
+    subject { presenter.to_s }
+
+    it { is_expected.to eq 'Hey guys!' }
+  end
+
+  describe "human_readable_type" do
+    let(:attributes) { { 'human_readable_type_tesim' => ['File'] } }
+    subject { presenter.human_readable_type }
+
+    it { is_expected.to eq 'File' }
+  end
+
+  describe "embargo_release_date" do
+    let(:attributes) { { 'embargo_release_date_dtsi' => '2015-10-15T00:00:00Z' } }
+    subject { presenter.embargo_release_date }
+
+    it { is_expected.to eq '15 Oct 2015' }
+  end
+
+  describe "visibility_after_embargo" do
+    let(:attributes) { { 'visibility_after_embargo_ssim' => ['restricted'] } }
+    subject { presenter.visibility_after_embargo }
+
+    it { is_expected.to eq 'restricted' }
+  end
+
+  describe "embargo_history" do
+    let(:attributes) { { 'embargo_history_ssim' => ['This is in the past'] } }
+    subject { presenter.embargo_history }
+
+    it { is_expected.to eq ['This is in the past'] }
+  end
+end

--- a/spec/presenters/lease_presenter_spec.rb
+++ b/spec/presenters/lease_presenter_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe CurationConcerns::LeasePresenter do
+  let(:document) { SolrDocument.new(attributes) }
+  let(:presenter) { described_class.new(document) }
+  let(:attributes) { {} }
+
+  describe "visibility" do
+    subject { presenter.visibility }
+
+    it { is_expected.to eq 'restricted' }
+  end
+
+  describe "to_s" do
+    let(:attributes) { { 'title_tesim' => ['Hey guys!'] } }
+    subject { presenter.to_s }
+
+    it { is_expected.to eq 'Hey guys!' }
+  end
+
+  describe "human_readable_type" do
+    let(:attributes) { { 'human_readable_type_tesim' => ['File'] } }
+    subject { presenter.human_readable_type }
+
+    it { is_expected.to eq 'File' }
+  end
+
+  describe "lease_expiration_date" do
+    let(:attributes) { { 'lease_expiration_date_dtsi' => '2015-10-15T00:00:00Z' } }
+    subject { presenter.lease_expiration_date }
+
+    it { is_expected.to eq '15 Oct 2015' }
+  end
+
+  describe "visibility_after_lease" do
+    let(:attributes) { { 'visibility_after_lease_ssim' => ['restricted'] } }
+    subject { presenter.visibility_after_lease }
+
+    it { is_expected.to eq 'restricted' }
+  end
+
+  describe "lease_history" do
+    let(:attributes) { { 'lease_history_ssim' => ['This is in the past'] } }
+    subject { presenter.lease_history }
+
+    it { is_expected.to eq ['This is in the past'] }
+  end
+end

--- a/spec/services/embargo_service_spec.rb
+++ b/spec/services/embargo_service_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe CurationConcerns::EmbargoService do
+  subject { described_class }
   let(:future_date) { 2.days.from_now }
   let(:past_date) { 2.days.ago }
 

--- a/spec/services/lease_service_spec.rb
+++ b/spec/services/lease_service_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe CurationConcerns::LeaseService do
+  subject { described_class }
   before { GenericWork.destroy_all }
 
   let(:future_date) { 2.days.from_now }


### PR DESCRIPTION
Reduced the number of queries from a linear number of queries against
Fedora to a constant number of queries on Solr. This results in a huge
speed improvement.