### PR TITLE
Ask if the Files' visibility should be updated

### DIFF
--- a/app/controllers/concerns/curation_concerns/embargoes_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/embargoes_controller_behavior.rb
@@ -14,10 +14,9 @@ module CurationConcerns
 
     # Removes a single embargo
     def destroy
-      update_files = !curation_concern.under_embargo? # embargo expired
       EmbargoActor.new(curation_concern).destroy
       flash[:notice] = curation_concern.embargo_history.last
-      if update_files
+      if curation_concern.works_generic_work? && curation_concern.generic_files.present?
         redirect_to confirm_curation_concerns_permission_path(curation_concern)
       else
         redirect_to edit_embargo_path(curation_concern)

--- a/app/controllers/concerns/curation_concerns/leases_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/leases_controller_behavior.rb
@@ -13,12 +13,13 @@ module CurationConcerns
     end
 
     def destroy
-      curation_concern.lease_visibility! # If the lease has lapsed, update the current visibility.
-      curation_concern.deactivate_lease!
-      saved = curation_concern.save
-      VisibilityCopyJob.perform_later(curation_concern.id) if saved
+      LeaseActor.new(curation_concern).destroy
       flash[:notice] = curation_concern.lease_history.last
-      redirect_to edit_lease_path(curation_concern)
+      if curation_concern.works_generic_work? && curation_concern.generic_files.present?
+        redirect_to confirm_curation_concerns_permission_path(curation_concern)
+      else
+        redirect_to edit_lease_path(curation_concern)
+      end
     end
 
     def update

--- a/curation_concerns-models/app/actors/curation_concerns/lease_actor.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/lease_actor.rb
@@ -1,0 +1,19 @@
+module CurationConcerns
+  class LeaseActor
+    attr_reader :work
+
+    # @param [Hydra::Works::Work] work
+    def initialize(work)
+      @work = work
+    end
+
+    # Update the visibility of the work to match the correct state of the lease, then clear the lease date, etc.
+    # Saves the lease and the work
+    def destroy
+      work.lease_visibility! # If the lease has lapsed, update the current visibility.
+      work.deactivate_lease!
+      work.lease.save!
+      work.save!
+    end
+  end
+end

--- a/spec/actors/curation_concerns/lease_actor_spec.rb
+++ b/spec/actors/curation_concerns/lease_actor_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe CurationConcerns::LeaseActor do
+  let(:actor) { described_class.new(work) }
+
+  let(:work) do
+    GenericWork.new do |work|
+      work.apply_depositor_metadata 'foo'
+      work.title = ["test"]
+      work.visibility_during_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      work.visibility_after_lease = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      work.lease_expiration_date = release_date.to_s
+      work.save(validate: false)
+    end
+  end
+
+  describe "#destroy" do
+    before do
+      actor.destroy
+    end
+
+    context "with an active lease" do
+      let(:release_date) { Date.today + 2 }
+
+      it "removes the lease" do
+        expect(work.reload.lease_expiration_date).to be_nil
+        expect(work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      end
+    end
+
+    context 'with an expired lease' do
+      let(:release_date) { Date.today - 2 }
+      it "removes the lease" do
+        expect(work.reload.lease_expiration_date).to be_nil
+        expect(work.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously Leases were updated automatically. Embargoes were asking if
you wanted to update the files, but only if the embargo had lapsed.
This simplifies the situation by treating Leases and Embargoes
identically and always asking if the visibility should be copied if they
have attached Files.