### PR TITLE
Draw the unauthorized template from any controller

### DIFF
--- a/app/controllers/concerns/curation_concerns/application_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/application_controller_behavior.rb
@@ -20,7 +20,7 @@ module CurationConcerns
         respond_to do |wants|
           wants.html do
             if [:show, :edit, :update, :destroy].include? exception.action
-              render 'unauthorized', status: :unauthorized
+              render 'curation_concerns/base/unauthorized', status: :unauthorized
             else
               redirect_to main_app.root_url, alert: exception.message
             end


### PR DESCRIPTION
This allows it to be used from any controller that doesn't have the
curation_concerns/base in the view search path.  Fixes an error like
this:

```
ActionView::MissingTemplate:
       Missing template admin_sets/unauthorized,
       application/unauthorized
```