### PR TITLE
Permit the `rights` attribute to be set

### DIFF
--- a/app/forms/curation_concerns/forms/work_form.rb
+++ b/app/forms/curation_concerns/forms/work_form.rb
@@ -24,6 +24,27 @@ module CurationConcerns
         Hash[file_presenters.map { |file| [file.to_s, file.id] }]
       end
 
+      class << self
+        # This determines whether the allowed parameters are single or multiple.
+        # By default it delegates to the model, but we need to override for
+        # 'rights' which only has a single value on the form.
+        def multiple?(term)
+          case term.to_s
+          when 'rights'
+            false
+          else
+            super
+          end
+        end
+
+        # Overriden to cast 'rights' to an array
+        def sanitize_params(form_params)
+          super.tap do |params|
+            params['rights'] = Array(params['rights']) if params.key?('rights')
+          end
+        end
+      end
+
       private
 
         # @return [Array<FileSetPresenter>] presenters for the file sets in order of the ids

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -101,6 +101,10 @@ describe CurationConcerns::GenericWorksController do
 
   describe '#update' do
     let(:a_work) { FactoryGirl.create(:private_generic_work, user: user) }
+    before do
+      allow(controller).to receive(:actor).and_return(actor)
+    end
+    let(:actor) { double(update: true, visibility_changed?: false) }
 
     it 'updates the work' do
       patch :update, id: a_work, generic_work: {}
@@ -108,16 +112,18 @@ describe CurationConcerns::GenericWorksController do
     end
 
     describe 'changing rights' do
+      let(:actor) { double(update: true, visibility_changed?: true) }
+
       it 'prompts to change the files access' do
-        allow(controller).to receive(:actor).and_return(double(update: true, visibility_changed?: true))
         patch :update, id: a_work
         expect(response).to redirect_to main_app.confirm_curation_concerns_permission_path(controller.curation_concern)
       end
     end
 
     describe 'failure' do
+      let(:actor) { double(update: false, visibility_changed?: false) }
+
       it 'renders the form' do
-        allow(controller).to receive(:actor).and_return(double(update: false, visibility_changed?: false))
         patch :update, id: a_work
         expect(assigns[:form]).to be_kind_of CurationConcerns::GenericWorkForm
         expect(response).to render_template('edit')

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -29,13 +29,20 @@ describe CurationConcerns::Forms::WorkForm do
   end
 
   describe '.model_attributes' do
-    let(:params) { ActionController::Parameters.new(title: ['foo'], description: [''], 'visibility' => 'open', admin_set_id: '123') }
+    let(:params) { ActionController::Parameters.new(
+      title: ['foo'],
+      description: [''],
+      visibility: 'open',
+      admin_set_id: '123',
+      rights: 'http://creativecommons.org/licenses/by/3.0/us/')
+    }
     subject { PirateShipForm.model_attributes(params) }
 
     it 'permits parameters' do
       expect(subject['title']).to eq ['foo']
       expect(subject['description']).to be_empty
       expect(subject['visibility']).to eq 'open'
+      expect(subject['rights']).to eq ['http://creativecommons.org/licenses/by/3.0/us/']
     end
 
     it 'excludes non-permitted params' do


### PR DESCRIPTION
Previously rights was not being permitted because the form has a
different cardinality than the data model. Updated the form to bridge
that mismatch.