### PR TITLE
Don't abuse the btn-primary style

### DIFF
--- a/app/views/collections/_show_actions.html.erb
+++ b/app/views/collections/_show_actions.html.erb
@@ -1,8 +1,8 @@
 <% if can? :edit, @presenter.id %>
   <h2 class="non lower">Actions</h2>
   <p>
-      <%= link_to "Edit", collections.edit_collection_path, class: 'btn btn-primary' %> &nbsp;&nbsp;
-      <%= link_to "Add files from your dashboard",  search_path_for_my_works, class: 'btn btn-primary' %>
+      <%= link_to "Edit", collections.edit_collection_path, class: 'btn btn-default' %> &nbsp;&nbsp;
+      <%= link_to "Add files from your dashboard",  search_path_for_my_works, class: 'btn btn-default' %>
   </p>
 <%end %>
 

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -16,9 +16,9 @@
 <% if collector || editor %>
   <div class="form-actions">
     <% if editor %>
-      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, :curation_concerns, @presenter]), class: 'btn btn-primary' %>
-      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, :curation_concerns, @presenter], class: 'btn btn-primary', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
-      <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-primary' %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, :curation_concerns, @presenter]), class: 'btn btn-default' %>
+      <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-default' %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, :curation_concerns, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
A page shouldn't have more than one primary button.  If it isn't obvious
which button is the primary, then make them all btn-default.