### PR TITLE
Don't singularize multivalue properties

### DIFF
--- a/curation_concerns-models/app/models/concerns/curation_concerns/solr_document_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/solr_document_behavior.rb
@@ -76,27 +76,27 @@ module CurationConcerns
     end
 
     def creator
-      Array(self[Solrizer.solr_name('creator')]).first
+      fetch(Solrizer.solr_name('creator'), [])
     end
 
     def contributor
-      Array(self[Solrizer.solr_name('contributor')]).first
+      fetch(Solrizer.solr_name('contributor'), [])
     end
 
     def subject
-      Array(self[Solrizer.solr_name('subject')]).first
+      fetch(Solrizer.solr_name('subject'), [])
     end
 
     def publisher
-      Array(self[Solrizer.solr_name('publisher')]).first
+      fetch(Solrizer.solr_name('publisher'), [])
     end
 
     def language
-      Array(self[Solrizer.solr_name('language')]).first
+      fetch(Solrizer.solr_name('language'), [])
     end
 
     def tags
-      Array(self[Solrizer.solr_name('tag')])
+      fetch(Solrizer.solr_name('tag'), [])
     end
 
     def embargo_release_date

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -10,6 +10,36 @@ describe SolrDocument do
     it { is_expected.to eq '08/31/2015' }
   end
 
+  describe "creator" do
+    let(:attributes) { { Solrizer.solr_name('creator') => ['one', 'two'] } }
+    subject { document.creator }
+    it { is_expected.to eq ['one', 'two'] }
+  end
+
+  describe "contributor" do
+    let(:attributes) { { Solrizer.solr_name('contributor') => ['one', 'two'] } }
+    subject { document.contributor }
+    it { is_expected.to eq ['one', 'two'] }
+  end
+
+  describe "subject" do
+    let(:attributes) { { Solrizer.solr_name('subject') => ['one', 'two'] } }
+    subject { document.subject }
+    it { is_expected.to eq ['one', 'two'] }
+  end
+
+  describe "publisher" do
+    let(:attributes) { { Solrizer.solr_name('publisher') => ['one', 'two'] } }
+    subject { document.publisher }
+    it { is_expected.to eq ['one', 'two'] }
+  end
+
+  describe "language" do
+    let(:attributes) { { Solrizer.solr_name('language') => ['one', 'two'] } }
+    subject { document.language }
+    it { is_expected.to eq ['one', 'two'] }
+  end
+
   describe "visibility" do
     subject { document.visibility }
 


### PR DESCRIPTION
I belived I added the `first` calls by mistake when these methods were
added. The effect was that multiple contributors, etc were not
displaying on the show view.