### PR TITLE
Moved DC and FOAF to RDF::Vocab

### DIFF
--- a/curation_concerns-models/app/models/concerns/curation_concerns/basic_metadata.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/basic_metadata.rb
@@ -15,33 +15,33 @@ module CurationConcerns
         index.as :symbol
       end
 
-      property :part_of, predicate: ::RDF::DC.isPartOf
-      property :resource_type, predicate: ::RDF::DC.type do |index|
+      property :part_of, predicate: ::RDF::Vocab::DC.isPartOf
+      property :resource_type, predicate: ::RDF::Vocab::DC.type do |index|
         index.as :stored_searchable, :facetable
       end
-      property :title, predicate: ::RDF::DC.title do |index|
+      property :title, predicate: ::RDF::Vocab::DC.title do |index|
         index.as :stored_searchable, :facetable
       end
-      property :creator, predicate: ::RDF::DC.creator do |index|
+      property :creator, predicate: ::RDF::Vocab::DC.creator do |index|
         index.as :stored_searchable, :facetable
       end
-      property :contributor, predicate: ::RDF::DC.contributor do |index|
+      property :contributor, predicate: ::RDF::Vocab::DC.contributor do |index|
         index.as :stored_searchable, :facetable
       end
-      property :description, predicate: ::RDF::DC.description do |index|
+      property :description, predicate: ::RDF::Vocab::DC.description do |index|
         index.type :text
         index.as :stored_searchable
       end
-      property :tag, predicate: ::RDF::DC.relation do |index|
+      property :tag, predicate: ::RDF::Vocab::DC.relation do |index|
         index.as :stored_searchable, :facetable
       end
-      property :rights, predicate: ::RDF::DC.rights do |index|
+      property :rights, predicate: ::RDF::Vocab::DC.rights do |index|
         index.as :stored_searchable
       end
-      property :publisher, predicate: ::RDF::DC.publisher do |index|
+      property :publisher, predicate: ::RDF::Vocab::DC.publisher do |index|
         index.as :stored_searchable, :facetable
       end
-      property :date_created, predicate: ::RDF::DC.created do |index|
+      property :date_created, predicate: ::RDF::Vocab::DC.created do |index|
         index.as :stored_searchable
       end
 
@@ -50,34 +50,34 @@ module CurationConcerns
       # fedora's system created date will reflect the date when the record
       # was created in fedora4, but the date_uploaded will preserve the
       # original creation date from the old repository.
-      property :date_uploaded, predicate: ::RDF::DC.dateSubmitted, multiple: false do |index|
+      property :date_uploaded, predicate: ::RDF::Vocab::DC.dateSubmitted, multiple: false do |index|
         index.type :date
         index.as :stored_sortable
       end
 
-      property :date_modified, predicate: ::RDF::DC.modified, multiple: false do |index|
+      property :date_modified, predicate: ::RDF::Vocab::DC.modified, multiple: false do |index|
         index.type :date
         index.as :stored_sortable
       end
-      property :subject, predicate: ::RDF::DC.subject do |index|
+      property :subject, predicate: ::RDF::Vocab::DC.subject do |index|
         index.as :stored_searchable, :facetable
       end
-      property :language, predicate: ::RDF::DC.language do |index|
+      property :language, predicate: ::RDF::Vocab::DC.language do |index|
         index.as :stored_searchable, :facetable
       end
-      property :identifier, predicate: ::RDF::DC.identifier do |index|
+      property :identifier, predicate: ::RDF::Vocab::DC.identifier do |index|
         index.as :stored_searchable
       end
-      property :based_near, predicate: ::RDF::FOAF.based_near do |index|
+      property :based_near, predicate: ::RDF::Vocab::FOAF.based_near do |index|
         index.as :stored_searchable, :facetable
       end
       property :related_url, predicate: ::RDF::RDFS.seeAlso do |index|
         index.as :stored_searchable
       end
-      property :bibliographic_citation, predicate: ::RDF::DC.bibliographicCitation do |index|
+      property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
         index.as :stored_searchable
       end
-      property :source, predicate: ::RDF::DC.source do |index|
+      property :source, predicate: ::RDF::Vocab::DC.source do |index|
         index.as :stored_searchable
       end
     end


### PR DESCRIPTION
The old constants are going to be deprecated in the RDF 2.0 gem.