### PR TITLE
Require the form to be filled out before submitting. Story curationexperts/goldenseal#232

### DIFF
--- a/app/views/collections/_form_to_add_member.html.erb
+++ b/app/views/collections/_form_to_add_member.html.erb
@@ -9,7 +9,7 @@
     <div class="form-group collection_id">
       <div class="controls">
         <%= select_tag :id, collection_options_for_select(collectible), prompt: 'Make a Selection',
-          class: 'form-control', :'aria-labelledby' => select_label_id %>
+          class: 'form-control', :'aria-labelledby' => select_label_id, required: 'required' %>
       </div>
     </div>
 


### PR DESCRIPTION
Submitting the form with no collection selected causes 404 error.  I made the field required so javascript would prompt the user before submitting the form.