### PR TITLE
IngestFileJob passes User to the callback

### DIFF
--- a/curation_concerns-models/app/jobs/ingest_file_job.rb
+++ b/curation_concerns-models/app/jobs/ingest_file_job.rb
@@ -10,7 +10,8 @@ class IngestFileJob < ActiveJob::Base
     # Tell UploadFileToGenericFile service to skip versioning because versions will be minted by VersionCommitter (called by save_characterize_and_record_committer) when necessary
     Hydra::Works::UploadFileToFileSet.call(file_set, file, versioning: false)
     file_set.save!
-    CurationConcerns::VersioningService.create(file_set.original_file, user_key)
-    CurationConcerns.config.callback.run(:after_create_content, file_set, user_key)
+    user = User.find_by_user_key(user_key)
+    CurationConcerns::VersioningService.create(file_set.original_file, user)
+    CurationConcerns.config.callback.run(:after_create_content, file_set, user)
   end
 end


### PR DESCRIPTION
Previously IngestFileJob was only passing the user_key. This made it
different from all the other jobs. Now all the jobs call the callback
with a user object.