### PR TITLE
Accomodate LocalFileIngest using FileSetActor with File instead of UploadedFile

### DIFF
--- a/curation_concerns-models/app/actors/curation_concerns/file_set_actor.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/file_set_actor.rb
@@ -50,12 +50,8 @@ module CurationConcerns
     # Simultaneously moving a preservation copy to the repostiory.
     # TODO: create a job to monitor this directory and prune old files that
     # have made it to the repo
-    # @param [ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user.
+    # @param [File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user.
     def create_content(file)
-      file_set.label ||= file.original_filename
-      file_set.title = [file_set.label] if file_set.title.blank?
-      return false unless file_set.save
-
       working_file = copy_file_to_working_directory(file, file_set.id)
       IngestFileJob.perform_later(file_set.id, working_file, file.content_type, user.user_key)
       make_derivative(file_set.id, working_file)
@@ -107,7 +103,7 @@ module CurationConcerns
         CharacterizeJob.perform_later(file_set_id, working_file)
       end
 
-      # @param [ActionDispatch::Http::UploadedFile] file
+      # @param [File, ActionDispatch::Http::UploadedFile] file
       # @param [String] id the identifer
       # @return [String] path of the working file
       def copy_file_to_working_directory(file, id)

--- a/curation_concerns-models/app/jobs/ingest_file_job.rb
+++ b/curation_concerns-models/app/jobs/ingest_file_job.rb
@@ -7,6 +7,10 @@ class IngestFileJob < ActiveJob::Base
     file.mime_type = mime_type
     file.original_name = File.basename(filename)
 
+    # Assign label and title of File Set after original_name has been determined.
+    file_set.label ||= file.original_filename
+    file_set.title = [file_set.label] if file_set.title.blank?
+
     # Tell UploadFileToGenericFile service to skip versioning because versions will be minted by VersionCommitter (called by save_characterize_and_record_committer) when necessary
     Hydra::Works::UploadFileToFileSet.call(file_set, file, versioning: false)
     file_set.save!


### PR DESCRIPTION
FileSetActor handling locally File ingest.
  Calling original_filename moved to IngestFileJob.
Update yard docs to indicate File as valid param type.
closes #456 