### PR TITLE
Handle ingest of File from IngestLocalFileJob

### DIFF
--- a/curation_concerns-models/app/jobs/ingest_file_job.rb
+++ b/curation_concerns-models/app/jobs/ingest_file_job.rb
@@ -3,13 +3,23 @@ class IngestFileJob < ActiveJob::Base
 
   def perform(file_set_id, filename, mime_type, user_key)
     file_set = FileSet.find(file_set_id)
-    file = Hydra::Derivatives::IoDecorator.new(File.open(filename, "rb"))
-    file.mime_type = mime_type
-    file.original_name = File.basename(filename)
 
-    # Tell UploadFileToGenericFile service to skip versioning because versions will be minted by VersionCommitter (called by save_characterize_and_record_committer) when necessary
-    Hydra::Works::UploadFileToFileSet.call(file_set, file, versioning: false)
+    file = File.open(filename, "rb")
+    # If mime-type is known, wrap in an IO decorator
+    # Otherwise allow Hydra::Works service to determine mime_type
+    if mime_type
+      file = Hydra::Derivatives::IoDecorator.new(file)
+      file.mime_type = mime_type
+      file.original_name = File.basename(filename)
+    end
+
+    # Tell AddFileToFileSet service to skip versioning because versions will be minted by VersionCommitter (called by save_characterize_and_record_committer) when necessary
+    Hydra::Works::AddFileToFileSet.call(file_set, file, :original_file, versioning: false)
+
+    # Persist changes to the file_set
     file_set.save!
+
+    # Do post file ingest actions
     user = User.find_by_user_key(user_key)
     CurationConcerns::VersioningService.create(file_set.original_file, user)
     CurationConcerns.config.callback.run(:after_create_content, file_set, user)

--- a/spec/controllers/curation_concerns/file_sets_controller_json_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_json_spec.rb
@@ -109,7 +109,7 @@ describe CurationConcerns::FileSetsController do
         post :update, id: resource, file_set: { title: nil, depositor: nil }, format: :json
       }
       it "returns 422 and the errors" do
-        expect(response).to respond_unprocessable_entity(errors: { "some_field": ["This is not valid. Fix it."] })
+        expect(response).to respond_unprocessable_entity(errors: { some_field: ["This is not valid. Fix it."] })
       end
     end
   end

--- a/spec/controllers/curation_concerns/generic_works_controller_json_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_json_spec.rb
@@ -78,7 +78,7 @@ describe CurationConcerns::GenericWorksController do
       before { post :update, id: resource, generic_work: { title: [] }, format: :json }
 
       it "returns 422 and the errors" do
-        expect(response).to respond_unprocessable_entity(errors: { "title": ["Your work must have a title."] })
+        expect(response).to respond_unprocessable_entity(errors: { title: ["Your work must have a title."] })
       end
     end
   end


### PR DESCRIPTION
Allow use of File in FileSetActor create_content.
Don't depend on original_filename and content_type.
Use AddFileToFileSet to avoid extra calls to save from IngestFileJob.
Update yard docs to indicate File as valid param type.
closes #456 