### PR TITLE
When an unauthorized user does create, show the unauthorized page

### DIFF
--- a/app/controllers/concerns/curation_concerns/application_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/application_controller_behavior.rb
@@ -19,7 +19,7 @@ module CurationConcerns
       if current_user && current_user.persisted?
         respond_to do |wants|
           wants.html do
-            if [:show, :edit, :update, :destroy].include? exception.action
+            if [:show, :edit, :create, :update, :destroy].include? exception.action
               render 'curation_concerns/base/unauthorized', status: :unauthorized
             else
               redirect_to main_app.root_url, alert: exception.message

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -58,6 +58,16 @@ describe CurationConcerns::GenericWorksController do
       end.to change { GenericWork.count }.by(1)
       expect(response).to redirect_to main_app.curation_concerns_generic_work_path(assigns[:curation_concern])
     end
+
+    context 'when not authorized' do
+      before { allow(controller.current_ability).to receive(:can?).and_return(false) }
+
+      it 'shows the unauthorized message' do
+        post :create, generic_work: { title: ['a title'] }
+        expect(response.code).to eq '401'
+        expect(response).to render_template(:unauthorized)
+      end
+    end
   end
 
   describe '#edit' do


### PR DESCRIPTION
rather than redirecting to the root path