### PR TITLE
Route models to correct controller

### DIFF
--- a/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
+++ b/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
@@ -72,7 +72,7 @@ module CurationConcerns::CurationConcernController
   # Gives the class of the form. Override this if you want
   # to use a different form.
   def form_class
-    CurationConcerns.const_get("#{self.class.curation_concern_type}Form")
+    CurationConcerns.const_get("#{self.class.curation_concern_type.to_s.demodulize}Form")
   end
 
   def edit
@@ -120,8 +120,8 @@ module CurationConcerns::CurationConcernController
 
     def after_create_response
       respond_to do |wants|
-        wants.html { redirect_to [main_app, :curation_concerns, curation_concern] }
-        wants.json { render :show, status: :created, location: polymorphic_path([main_app, :curation_concerns, curation_concern]) }
+        wants.html { redirect_to [main_app, curation_concern] }
+        wants.json { render :show, status: :created, location: polymorphic_path([main_app, curation_concern]) }
       end
     end
 
@@ -131,8 +131,8 @@ module CurationConcerns::CurationConcernController
         redirect_to main_app.confirm_curation_concerns_permission_path(curation_concern)
       else
         respond_to do |wants|
-          wants.html { redirect_to [main_app, :curation_concerns, curation_concern] }
-          wants.json { render :show, status: :ok, location: polymorphic_path([main_app, :curation_concerns, curation_concern]) }
+          wants.html { redirect_to [main_app, curation_concern] }
+          wants.json { render :show, status: :ok, location: polymorphic_path([main_app, curation_concern]) }
         end
       end
     end
@@ -150,6 +150,6 @@ module CurationConcerns::CurationConcernController
     end
 
     def hash_key_for_curation_concern
-      self.class.curation_concern_type.name.underscore.to_sym
+      self.class.curation_concern_type.model_name.param_key
     end
 end

--- a/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
@@ -78,7 +78,7 @@ module CurationConcerns
 
     def destroy
       actor.destroy
-      redirect_to [main_app, :curation_concerns, @file_set.in_works.first], notice: 'The file has been deleted.'
+      redirect_to [main_app, @file_set.in_works.first], notice: 'The file has been deleted.'
     end
 
     # routed to /files/:id (PUT)
@@ -95,10 +95,9 @@ module CurationConcerns
       if success
         respond_to do |wants|
           wants.html do
-            redirect_to [main_app, :curation_concerns, @file_set], notice:
-                                                                         "The file #{view_context.link_to(@file_set, [main_app, :curation_concerns, @file_set])} has been updated."
+            redirect_to [main_app, @file_set], notice: "The file #{view_context.link_to(@file_set, [main_app, @file_set])} has been updated."
           end
-          wants.json { render :show, status: :ok, location: polymorphic_path([main_app, :curation_concerns, @file_set]) }
+          wants.json { render :show, status: :ok, location: polymorphic_path([main_app, @file_set]) }
         end
       else
         respond_to do |wants|
@@ -183,11 +182,11 @@ module CurationConcerns
               if request.xhr?
                 render 'jq_upload', formats: 'json', content_type: 'text/html'
               else
-                redirect_to [main_app, :curation_concerns, @file_set.in_works.first]
+                redirect_to [main_app, @file_set.in_works.first]
               end
             end
             format.json do
-              render 'jq_upload', status: :created, location: polymorphic_path([main_app, :curation_concerns, curation_concern])
+              render 'jq_upload', status: :created, location: polymorphic_path([main_app, curation_concern])
             end
           end
         else

--- a/app/controllers/concerns/curation_concerns/single_use_links_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/single_use_links_controller_behavior.rb
@@ -26,7 +26,7 @@ module CurationConcerns
     end
 
     def new_show
-      @su = SingleUseLink.create itemId: params[:id], path: polymorphic_path([main_app, :curation_concerns, asset])
+      @su = SingleUseLink.create itemId: params[:id], path: polymorphic_path([main_app, asset])
       @link = curation_concerns.show_single_use_link_path(@su.downloadKey)
 
       respond_to do |format|

--- a/app/controllers/concerns/curation_concerns/single_use_links_viewer_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/single_use_links_viewer_controller_behavior.rb
@@ -29,7 +29,7 @@ module CurationConcerns
       # Authorize using SingleUseLinksViewerController::Ability
       authorize! :read, curation_concern
 
-      raise not_found_exception unless single_use_link.path == polymorphic_path([main_app, :curation_concerns, curation_concern])
+      raise not_found_exception unless single_use_link.path == polymorphic_path([main_app, curation_concern])
 
       # show the file
       @presenter = presenter_class.new(curation_concern, current_ability)

--- a/app/controllers/curation_concerns/permissions_controller.rb
+++ b/app/controllers/curation_concerns/permissions_controller.rb
@@ -9,7 +9,7 @@ class CurationConcerns::PermissionsController < ApplicationController
   def copy
     VisibilityCopyJob.perform_later(curation_concern.id)
     flash_message = 'Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions.'
-    redirect_to polymorphic_path([main_app, :curation_concerns, curation_concern]), notice: flash_message
+    redirect_to [main_app, curation_concern], notice: flash_message
   end
 
   def curation_concern

--- a/app/helpers/curation_concerns/file_set_helper.rb
+++ b/app/helpers/curation_concerns/file_set_helper.rb
@@ -3,7 +3,7 @@ module CurationConcerns::FileSetHelper
     if parent.is_a?(Collection)
       main_app.collection_path(parent)
     else
-      polymorphic_path([main_app, :curation_concerns, parent])
+      polymorphic_path([main_app, parent])
     end
   end
 

--- a/app/helpers/curation_concerns/url_helper.rb
+++ b/app/helpers/curation_concerns/url_helper.rb
@@ -6,22 +6,14 @@ module CurationConcerns
       if doc.collection?
         doc
       else
-        polymorphic_path([main_app, :curation_concerns, doc])
+        polymorphic_path([main_app, doc])
       end
-    end
-
-    def track_collection_path(*args)
-      main_app.track_solr_document_path(*args)
-    end
-
-    def track_file_set_path(*args)
-      main_app.track_solr_document_path(*args)
     end
 
     # generated new GenericWork models get registered as curation concerns and need a
     # track_model_path to render Blacklight-related views
-    CurationConcerns.config.registered_curation_concern_types.each do |concern|
-      define_method("track_#{concern.underscore}_path") { |*args| main_app.track_solr_document_path(*args) }
+    (['FileSet', 'Collection'] + CurationConcerns.config.registered_curation_concern_types).each do |concern|
+      define_method("track_#{concern.constantize.model_name.singular_route_key}_path") { |*args| main_app.track_solr_document_path(*args) }
     end
   end
 end

--- a/app/views/catalog/_action_menu_partials/_default.html.erb
+++ b/app/views/catalog/_action_menu_partials/_default.html.erb
@@ -4,14 +4,14 @@
     <ul class="dropdown-menu">
       <% if can? :edit, document %>
         <li>
-          <%= link_to [:edit, :curation_concerns, document], class: 'itemicon itemedit' do %><i class="glyphicon glyphicon-pencil"></i> Edit <%= document.human_readable_type %>
+          <%= link_to [:edit, document], class: 'itemicon itemedit' do %><i class="glyphicon glyphicon-pencil"></i> Edit <%= document.human_readable_type %>
           <% end %>
         </li>
         <li>
           <% if @collection || (@presenter and @presenter.collection?) # We're on the view page for @collection. -%>
             <%= link_to_remove_from_collection(document) %>
           <% else %>
-            <%= link_to [:curation_concerns, document], class: 'itemicon itemtrash',
+            <%= link_to document, class: 'itemicon itemtrash',
                         title: "Delete #{document.human_readable_type}", method: :delete,
                         data: {
                           confirm: "Deleting a #{document.human_readable_type} from #{t('curation_concerns.product_name')} is permanent. Click OK to delete this #{document.human_readable_type} from #{t('curation_concerns.product_name')}, or Cancel to cancel this operation" } do %>

--- a/app/views/curation_concerns/base/_form.html.erb
+++ b/app/views/curation_concerns/base/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [main_app, :curation_concerns, curation_concern],
+<%= simple_form_for [main_app, curation_concern],
                     wrapper_mappings: { multifile: :horizontal_file_input } do |f| %>
   <% if f.error_notification -%>
     <div class="alert alert-danger fade in">
@@ -16,7 +16,7 @@
       <%- if curation_concern.new_record? -%>
         <%= link_to 'Cancel', main_app.root_path, class: 'btn btn-link' %>
       <%- else -%>
-        <%= link_to 'Cancel', polymorphic_path([main_app, :curation_concerns, curation_concern]), class: 'btn btn-link' %>
+        <%= link_to 'Cancel', polymorphic_path([main_app, curation_concern]), class: 'btn btn-link' %>
       <%- end -%>
     </div>
   </div>

--- a/app/views/curation_concerns/base/_show_actions.html.erb
+++ b/app/views/curation_concerns/base/_show_actions.html.erb
@@ -1,9 +1,9 @@
 <% if collector || editor %>
   <div class="form-actions">
     <% if editor %>
-      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, :curation_concerns, @presenter]), class: 'btn btn-default' %>
+      <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
       <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-default' %>
-      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, :curation_concerns, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
+      <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/curation_concerns/base/_versioning.html.erb
+++ b/app/views/curation_concerns/base/_versioning.html.erb
@@ -2,7 +2,7 @@
   <h2>Versions</h2>
   <div class="well">
 
-    <%= form_for [main_app, :curation_concerns, curation_concern], html: { multipart: true } do |f| %>
+    <%= form_for [main_app, curation_concern], html: { multipart: true } do |f| %>
     <h3>Restore Previous Version</h3>
     <% @version_list.each do |version| %>
       <div class="form-group">

--- a/app/views/curation_concerns/classify_concerns/new.html.erb
+++ b/app/views/curation_concerns/classify_concerns/new.html.erb
@@ -12,7 +12,7 @@
           <h3 class="title"><%= klass.human_readable_type %></h3>
           <p class="short-description"><%= klass.human_readable_short_description %></p>
           <%= link_to 'Add New',
-            main_app.new_polymorphic_path([:curation_concerns, klass]),
+            main_app.new_polymorphic_path(klass),
             class: "add-button btn btn-primary #{dom_class(klass, 'add_new')}"
           %>
         </li>

--- a/app/views/curation_concerns/file_sets/_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_actions.html.erb
@@ -1,11 +1,11 @@
 <% if can?(:edit, file_set.id) %>
-  <%= link_to( 'Edit', edit_polymorphic_path([main_app, :curation_concerns, file_set]),
+  <%= link_to( 'Edit', edit_polymorphic_path([main_app, file_set]),
     { class: 'btn btn-default', title: "Edit #{file_set}" }) %>
   <%= link_to( 'Rollback', main_app.versions_curation_concerns_file_set_path(file_set),
     { class: 'btn btn-default', title: "Rollback to previous version" }) %>
 <% end %>
 <% if can?(:destroy, file_set.id) %>
-  <%= link_to( 'Delete', polymorphic_path([main_app, :curation_concerns, file_set]),
+  <%= link_to( 'Delete', polymorphic_path([main_app, file_set]),
     class: 'btn btn-default', method: :delete, title: "Delete #{file_set}",
     data: {confirm: "Deleting #{file_set} from #{t('curation_concerns.product_name')} is permanent. Click OK to delete this from #{t('curation_concerns.product_name')}, or Cancel to cancel this operation"}
   )%>

--- a/app/views/curation_concerns/file_sets/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for [main_app, :curation_concerns, curation_concern],
+<%= simple_form_for [main_app, curation_concern],
                     html: { multipart: true },
                     wrapper_mappings: { multifile: :horizontal_file_input } do |f| %>
   <div class="row">

--- a/app/views/curation_concerns/file_sets/show.html.erb
+++ b/app/views/curation_concerns/file_sets/show.html.erb
@@ -8,7 +8,7 @@
   <div class="form-actions">
     <%= link_to "Download this File", main_app.download_path(@presenter), class: 'btn btn-default' %>
     <% if can? :edit, @presenter.id %>
-      <%= link_to "Edit this File", edit_polymorphic_path([main_app, :curation_concerns, @presenter]), class: 'btn btn-default'  %>
+      <%= link_to "Edit this File", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default'  %>
     <% end %>
 
     <%= link_to "Back to #{parent.human_readable_type}", parent_path(parent), class: 'btn btn-default' %>

--- a/app/views/curation_concerns/file_sets/upload/_alerts.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_alerts.html.erb
@@ -2,17 +2,17 @@
 <div class="alert alert-info hide" id="success">
   You have successfully uploaded some of your files.  Either continue to upload or edit use the links below to abandon the rest of your added files.
   <p>
-  <%= link_to 'Add Descriptions', edit_polymorphic_path([main_app, :curation_concerns, @presenter]), class: 'btn' %>
+  <%= link_to 'Add Descriptions', edit_polymorphic_path([main_app, @presenter]), class: 'btn' %>
   </p>
 </div>
 
 <div class="alert hide" id="fail">
-  There was a problem during upload. Please click the &quot;Start Upload&quot; button or <%= link_to 'start over', edit_polymorphic_path([main_app, :curation_concerns, @presenter]) %>
+  There was a problem during upload. Please click the &quot;Start Upload&quot; button or <%= link_to 'start over', edit_polymorphic_path([main_app, @presenter]) %>
 </div>
 
 <div class="alert hide" id="partial_fail">
   One or more files did not upload successfully. To continue using the files uploaded use one of the links below.<br />
-  <%= link_to 'Add Descriptions', edit_polymorphic_path([main_app, :curation_concerns, @presenter]), class: 'btn' %>
+  <%= link_to 'Add Descriptions', edit_polymorphic_path([main_app, @presenter]), class: 'btn' %>
 </div>
 
 <div class="alert hide" id="errmsg"> </div>

--- a/app/views/curation_concerns/file_sets/upload/_script_templates.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_script_templates.html.erb
@@ -1,6 +1,6 @@
 <div class="alert alert-info hide" id="redirect-loc" type="text/x-jquery-tmpl">
   <%-# Script redirects here once the uploads are complete %>
-  <%= polymorphic_path([main_app, :curation_concerns, @presenter]) %>
+  <%= polymorphic_path([main_app, @presenter]) %>
 </div>
 
 <!-- The template to display files available for upload -->

--- a/app/views/curation_concerns/permissions/confirm.html.erb
+++ b/app/views/curation_concerns/permissions/confirm.html.erb
@@ -16,6 +16,6 @@
   </div>
   <div class="form-actions panel-footer">
     <%= button_to "Yes please.", main_app.copy_curation_concerns_permission_path(curation_concern), class: 'btn btn-primary' %>
-    <%= link_to "No. I'll update it manually.", polymorphic_path([main_app, :curation_concerns, curation_concern]), class: 'btn' %>
+    <%= link_to "No. I'll update it manually.", polymorphic_path([main_app, curation_concern]), class: 'btn' %>
   </div>
 </div>

--- a/app/views/embargoes/edit.html.erb
+++ b/app/views/embargoes/edit.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <h2>Current Embargo</h2>
-<%= simple_form_for [:curation_concerns, curation_concern] do |f| %>
+<%= simple_form_for [main_app, curation_concern] do |f| %>
   <fieldset id="set-access-controls">
     <section class="help-block">
       <p>
@@ -25,12 +25,12 @@
     <div class="col-md-12 form-actions">
       <% if curation_concern.embargo_release_date %>
         <%= f.submit "Update Embargo", class: 'btn btn-primary' %>
-        <%= link_to "Deactivate Embargo", embargo_path(curation_concern), :method => :delete, class: 'btn btn-danger' %>
+        <%= link_to "Deactivate Embargo", embargo_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
       <% else %>
         <%= f.submit "Apply Embargo", class: 'btn btn-primary' %>
       <% end %>
       <%= link_to 'Cancel and manage all embargoes', embargoes_path, class: 'btn btn-default' %>
-      <%= link_to "Return to editing this #{curation_concern.human_readable_type}", edit_polymorphic_path([:curation_concerns, curation_concern]), class: 'btn btn-default' %>
+      <%= link_to "Return to editing this #{curation_concern.human_readable_type}", [:edit, curation_concern], class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>
@@ -39,5 +39,5 @@
 <% if curation_concern.embargo_history.empty? %>
   This <%= curation_concern.human_readable_type %> has never had embargoes applied to it.
 <% else %>
-  <%= render partial:"embargo_history" %>
+  <%= render partial: "embargo_history" %>
 <% end %>

--- a/app/views/leases/edit.html.erb
+++ b/app/views/leases/edit.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <h2>Current Lease</h2>
-<%= simple_form_for [:curation_concerns, curation_concern] do |f| %>
+<%= simple_form_for curation_concern do |f| %>
   <fieldset id="set-access-controls">
     <section class="help-block">
       <p>
@@ -25,12 +25,12 @@
     <div class="col-md-12 form-actions">
       <% if curation_concern.lease_expiration_date %>
         <%= f.submit "Update Lease", class: 'btn btn-primary' %>
-        <%= link_to "Deactivate Lease", lease_path(curation_concern), :method => :delete, class: 'btn btn-danger' %>
+        <%= link_to "Deactivate Lease", lease_path(curation_concern), method: :delete, class: 'btn btn-danger' %>
       <% else %>
         <%= f.submit "Apply Lease", class: 'btn btn-primary' %>
       <% end %>
       <%= link_to 'Cancel and manage all leases', leases_path, class: 'btn btn-default' %>
-      <%= link_to "Return to editing this #{curation_concern.human_readable_type}", edit_polymorphic_path([:curation_concerns, curation_concern]), class: 'btn btn-default' %>
+      <%= link_to "Return to editing this #{curation_concern.human_readable_type}", [:edit, curation_concern], class: 'btn btn-default' %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_add_works.html.erb
+++ b/app/views/shared/_add_works.html.erb
@@ -3,7 +3,7 @@
             <% CurationConcerns::QuickClassificationQuery.each_for_context(current_user) do |concern| %>
               <li><%= link_to(
                     "New #{concern.human_readable_type}",
-                    main_app.new_polymorphic_path([:curation_concerns, concern]),
+                    new_polymorphic_path([main_app, concern]),
                     class: "item-option contextual-quick-classify #{dom_class(concern, 'new').gsub('_', '-')}",
                     role: 'menuitem'
                   ) %>

--- a/curation_concerns-models/app/models/concerns/curation_concerns/file_set_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/file_set_behavior.rb
@@ -15,6 +15,7 @@ module CurationConcerns
     include CurationConcerns::FileSet::BelongsToWorks
     include CurationConcerns::FileSet::BelongsToUploadSets
     include CurationConcerns::HumanReadableType
+    include CurationConcerns::Naming
     include Hydra::AccessControls::Embargoable
 
     included do

--- a/curation_concerns-models/app/models/concerns/curation_concerns/naming.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/naming.rb
@@ -1,0 +1,17 @@
+module CurationConcerns
+  module Naming
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Override of ActiveModel::Model name that allows us to use our custom name class
+      def model_name
+        @_model_name ||= begin
+          namespace = parents.detect do |n|
+            n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
+          end
+          CurationConcerns::Name.new(self, namespace)
+        end
+      end
+    end
+  end
+end

--- a/curation_concerns-models/app/models/concerns/curation_concerns/work_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/work_behavior.rb
@@ -2,14 +2,15 @@ module CurationConcerns::WorkBehavior
   extend ActiveSupport::Concern
 
   include Hydra::Works::WorkBehavior
-  include ::CurationConcerns::HumanReadableType
+  include CurationConcerns::HumanReadableType
   include CurationConcerns::Noid
   include CurationConcerns::Permissions
   include CurationConcerns::Serializers
   include Hydra::WithDepositor
   include Solrizer::Common
-  include ::CurationConcerns::HasRepresentative
-  include ::CurationConcerns::WithFileSets
+  include CurationConcerns::HasRepresentative
+  include CurationConcerns::WithFileSets
+  include CurationConcerns::Naming
   include Hydra::AccessControls::Embargoable
 
   included do
@@ -31,11 +32,6 @@ module CurationConcerns::WorkBehavior
     else
       'No Title'
     end
-  end
-
-  # Returns a string identifying the path associated with the object. ActionPack uses this to find a suitable partial to represent the object.
-  def to_partial_path
-    "curation_concerns/#{super}"
   end
 
   def can_be_member_of_collection?(_collection)

--- a/curation_concerns-models/lib/curation_concerns/models.rb
+++ b/curation_concerns-models/lib/curation_concerns/models.rb
@@ -13,6 +13,7 @@ module CurationConcerns
   autoload :Messages
   eager_autoload do
     autoload :Configuration
+    autoload :Name
   end
 
   attr_writer :queue

--- a/curation_concerns-models/lib/curation_concerns/name.rb
+++ b/curation_concerns-models/lib/curation_concerns/name.rb
@@ -1,0 +1,20 @@
+module CurationConcerns
+  # A model name that provides routes that are namespaced to CurationConcerns,
+  # without changing the param key.
+  #
+  # Example:
+  #   name = CurationConcerns::Name.new(GenericWork)
+  #   name.param_key
+  #   # => 'generic_work'
+  #   name.route_key
+  #   # => 'curation_concerns_generic_works'
+  #
+  class Name < ActiveModel::Name
+    def initialize(klass, namespace = nil, name = nil)
+      super
+      @route_key          = "curation_concerns_#{ActiveSupport::Inflector.pluralize(@param_key)}"
+      @singular_route_key = ActiveSupport::Inflector.singularize(@route_key)
+      @route_key << "_index" if @plural == @singular
+    end
+  end
+end

--- a/lib/curation_concerns/engine.rb
+++ b/lib/curation_concerns/engine.rb
@@ -7,6 +7,11 @@ require 'jquery-ui-rails'
 require 'qa'
 
 module CurationConcerns
+  # Ensures that routes to curation_concerns are prefixed with `curation_concerns_`
+  # def self.use_relative_model_naming?
+  #   false
+  # end
+
   class Engine < ::Rails::Engine
     isolate_namespace CurationConcerns
     require 'breadcrumbs_on_rails'

--- a/lib/curation_concerns/rails/routes.rb
+++ b/lib/curation_concerns/rails/routes.rb
@@ -10,6 +10,7 @@ module ActionDispatch::Routing
         CurationConcerns.config.registered_curation_concern_types.map(&:tableize).each do |curation_concern_name|
           namespaced_resources curation_concern_name, except: [:index]
         end
+
         resources :permissions, only: [] do
           member do
             get :confirm
@@ -60,16 +61,19 @@ module ActionDispatch::Routing
 
     private
 
+      # routing namepace arguments, for using a path other than the default
+      ROUTE_OPTIONS = { 'curation_concerns' => { path: :concern } }
+
       # Namespaces routes appropriately
       # @example route_namespaced_target("curation_concerns/generic_work") is equivalent to
-      #   namespace "curation_concerns" do
+      #   namespace "curation_concerns", path: :concern do
       #     resources "generic_work", except: [:index]
       #   end
       def namespaced_resources(target, opts = {})
         if target.include?('/')
           the_namespace = target[0..target.index('/') - 1]
           new_target = target[target.index('/') + 1..-1]
-          namespace the_namespace do
+          namespace the_namespace, ROUTE_OPTIONS.fetch(the_namespace, nil) do
             namespaced_resources(new_target, opts)
           end
         else

--- a/lib/generators/curation_concerns/work/work_generator.rb
+++ b/lib/generators/curation_concerns/work/work_generator.rb
@@ -65,7 +65,7 @@ class CurationConcerns::WorkGenerator < Rails::Generators::NamedBase
   end
 
   def create_views
-    create_file "app/views/curation_concerns/#{plural_file_name}/_#{file_name}.html.erb" do
+    create_file "app/views/#{plural_file_name}/_#{file_name}.html.erb" do
       "<%# This is a search result view %>\n" \
       "<%= render 'catalog/document', document: #{file_name}, document_counter: #{file_name}_counter  %>\n"
     end

--- a/spec/controllers/curation_concerns/generic_works_controller_json_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_json_spec.rb
@@ -36,7 +36,7 @@ describe CurationConcerns::GenericWorksController do
       before { post :create, generic_work: { title: ['a title'] }, format: :json }
       it "returns 201, renders show template sets location header" do
         # Ensure that @curation_concern is set for jbuilder template to use
-        expect(assigns[:curation_concern]).to be_instance_of ::GenericWork
+        expect(assigns[:curation_concern]).to be_instance_of GenericWork
         expect(controller).to render_template('curation_concerns/base/show')
         expect(response.code).to eq "201"
         created_resource = assigns[:curation_concern]
@@ -56,7 +56,7 @@ describe CurationConcerns::GenericWorksController do
       before { resource_request }
       it "returns json of the work" do
         # Ensure that @curation_concern is set for jbuilder template to use
-        expect(assigns[:curation_concern]).to be_instance_of ::GenericWork
+        expect(assigns[:curation_concern]).to be_instance_of GenericWork
         expect(controller).to render_template('curation_concerns/base/show')
         expect(response.code).to eq "200"
       end
@@ -66,7 +66,7 @@ describe CurationConcerns::GenericWorksController do
       before { put :update, id: resource, generic_work: { title: ['updated title'] }, format: :json }
       it "returns 200, renders show template sets location header" do
         # Ensure that @curation_concern is set for jbuilder template to use
-        expect(assigns[:curation_concern]).to be_instance_of ::GenericWork
+        expect(assigns[:curation_concern]).to be_instance_of GenericWork
         expect(controller).to render_template('curation_concerns/base/show')
         expect(response.code).to eq "200"
         created_resource = assigns[:curation_concern]

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -21,10 +21,8 @@ describe 'collection' do
   let(:user_key) { user.user_key }
   let(:generic_works) do
     (0..12).map do |x|
-      GenericWork.new.tap do |f|
-        f.title = ["title #{x}"]
+      GenericWork.create!(title: ["title #{x}"]) do |f|
         f.apply_depositor_metadata('user1@example.com')
-        f.save!
       end
     end
   end

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
 describe CurationConcerns::UrlHelper do
-  before do
-    GenericWork.destroy_all
-  end
   let(:profile) { ["{\"datastreams\":{}}"] }
   let(:work) { create(:generic_work) }
   let(:document) { SolrDocument.new(work.to_solr) }

--- a/spec/lib/curation_concerns/name_spec.rb
+++ b/spec/lib/curation_concerns/name_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe CurationConcerns::Name do
+  let(:name) { described_class.new(GenericWork) }
+
+  describe "route_key" do
+    subject { name.route_key }
+    it { is_expected.to eq 'curation_concerns_generic_works' }
+  end
+
+  describe "singular_route_key" do
+    subject { name.singular_route_key }
+    it { is_expected.to eq 'curation_concerns_generic_work' }
+  end
+
+  describe "param_key" do
+    subject { name.param_key }
+    it { is_expected.to eq 'generic_work' }
+  end
+end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -9,6 +9,11 @@ describe GenericWork do
     expect(subject.title).to eq ['foo']
   end
 
+  describe '.model_name' do
+    subject { described_class.model_name.singular_route_key }
+    it { is_expected.to eq 'curation_concerns_generic_work' }
+  end
+
   context 'with attached files' do
     subject { FactoryGirl.create(:work_with_files) }
 
@@ -39,6 +44,6 @@ describe GenericWork do
   describe '#to_partial_path' do
     let(:work) { described_class.new }
     subject { work.to_partial_path }
-    it { is_expected.to eq 'curation_concerns/generic_works/generic_work' }
+    it { is_expected.to eq 'generic_works/generic_work' }
   end
 end

--- a/spec/routing/curation_concerns/routes_spec.rb
+++ b/spec/routing/curation_concerns/routes_spec.rb
@@ -50,12 +50,12 @@ module CurationConcerns
       it 'routes to #show' do
         expect(curation_concerns_generic_work_path(generic_work)).to eq "/concern/generic_works/#{generic_work.id}"
         expect(get("/concern/generic_works/#{generic_work.id}")).to route_to(controller: 'curation_concerns/generic_works', action: 'show', id: generic_work.id)
-        expect(url_for([:curation_concerns, generic_work, only_path: true])).to eq "/concern/generic_works/#{generic_work.id}"
+        expect(url_for([generic_work, only_path: true])).to eq "/concern/generic_works/#{generic_work.id}"
       end
       it 'routes to #edit' do
         expect(edit_curation_concerns_generic_work_path(generic_work)).to eq "/concern/generic_works/#{generic_work.id}/edit"
         expect(get("/concern/generic_works/#{generic_work.id}/edit")).to route_to(controller: 'curation_concerns/generic_works', action: 'edit', id: generic_work.id)
-        expect(url_for([:edit, :curation_concerns, generic_work, only_path: true])).to eq "/concern/generic_works/#{generic_work.id}/edit"
+        expect(url_for([:edit, generic_work, only_path: true])).to eq "/concern/generic_works/#{generic_work.id}/edit"
       end
     end
   end

--- a/spec/views/curation_concerns/base/show.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/show.html.erb_spec.rb
@@ -31,7 +31,7 @@ describe 'curation_concerns/base/show.html.erb' do
 
     it 'draws the page' do
       expect(rendered).to have_link 'Attribution 3.0 United States', href: 'http://creativecommons.org/licenses/by/3.0/us/'
-      expect(rendered).to have_link 'Edit This Generic Work', href: edit_polymorphic_path([:curation_concerns, presenter])
+      expect(rendered).to have_link 'Edit This Generic Work', href: edit_polymorphic_path(presenter)
     end
   end
 

--- a/spec/views/curation_concerns/file_sets/_file_set.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/_file_set.html.erb_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'curation_concerns/file_sets/_file_set.html.erb' do
   let(:solr_document) { SolrDocument.new(id: '999',
                                          has_model_ssim: ['FileSet'],
+                                         active_fedora_model_ssi: 'FileSet',
                                          thumbnail_path_ss: '/downloads/999?file=thumbnail',
                                          representative_tesim: ["999"],
                                          title_tesim: ["My File"]) }
@@ -28,9 +29,9 @@ describe 'curation_concerns/file_sets/_file_set.html.erb' do
     expect(rendered).to have_selector ".thumbnail img[src='#{download_path(presenter, file: 'thumbnail')}']"
 
     # Action buttons
-    expect(rendered).to have_selector "a[title=\"Edit My File\"][href='#{edit_polymorphic_path([:curation_concerns, presenter])}']", text: 'Edit'
+    expect(rendered).to have_selector "a[title=\"Edit My File\"][href='#{edit_polymorphic_path(presenter)}']", text: 'Edit'
     expect(rendered).to have_selector "a[title=\"Rollback to previous version\"][href='#{versions_curation_concerns_file_set_path(presenter)}']", text: 'Rollback'
-    expect(rendered).to have_selector "a[title=\"Delete My File\"][data-method='delete'][href='#{polymorphic_path([:curation_concerns, presenter])}']", text: 'Delete'
+    expect(rendered).to have_selector "a[title=\"Delete My File\"][data-method='delete'][href='#{polymorphic_path(presenter)}']", text: 'Delete'
     expect(rendered).to have_link('Download')
     expect(rendered).to have_selector "a[title='Download \"My File\"'][href='#{download_path(presenter)}']", text: 'Download'
   end

--- a/spec/views/shared/_add_content.html.erb_spec.rb
+++ b/spec/views/shared/_add_content.html.erb_spec.rb
@@ -14,7 +14,7 @@ describe 'shared/_add_content.html.erb' do
 
     it 'has links to create works and collections' do
       CurationConcerns.config.curation_concerns.each do |curation_concern_type|
-        expect(rendered).to have_link("New #{curation_concern_type.human_readable_type}", href: new_polymorphic_path([:curation_concerns, curation_concern_type]))
+        expect(rendered).to have_link("New #{curation_concern_type.human_readable_type}", href: new_polymorphic_path(curation_concern_type))
       end
       expect(rendered).to have_link('Add a Collection', href: collections.new_collection_path)
     end
@@ -30,7 +30,7 @@ describe 'shared/_add_content.html.erb' do
 
     it 'has links to add collections but not to add works' do
       CurationConcerns.config.curation_concerns.each do |curation_concern_type|
-        expect(rendered).not_to have_link("New #{curation_concern_type.human_readable_type}", href: new_polymorphic_path([:curation_concerns, curation_concern_type]))
+        expect(rendered).not_to have_link("New #{curation_concern_type.human_readable_type}", href: new_polymorphic_path(curation_concern_type))
       end
       expect(rendered).to have_link('Add a Collection', href: collections.new_collection_path)
     end
@@ -47,7 +47,7 @@ describe 'shared/_add_content.html.erb' do
       expect(rendered).not_to have_text('Add')
       expect(rendered).not_to have_text('Admin')
       CurationConcerns.config.curation_concerns.each do |curation_concern_type|
-        expect(rendered).not_to have_link("New #{curation_concern_type.human_readable_type}", href: new_polymorphic_path([:curation_concerns, curation_concern_type]))
+        expect(rendered).not_to have_link("New #{curation_concern_type.human_readable_type}", href: new_polymorphic_path(curation_concern_type))
       end
       expect(rendered).not_to have_link('Add a Collection', href: collections.new_collection_path)
     end


### PR DESCRIPTION
Ref #463  This is the alternative to #464 where we don't have to change the namespace of models.  I think I prefer this approach.