### PR TITLE
Allow sort_and_per_page to be used for edit

### DIFF
--- a/app/views/collections/_sort_and_per_page.html.erb
+++ b/app/views/collections/_sort_and_per_page.html.erb
@@ -1,29 +1,31 @@
 <div class="batch-info">
   <div>
-    <%= render partial: 'collections/form_for_select_collection', locals: { user_collections: @user_collections }  %>
+    <%= render 'collections/form_for_select_collection', user_collections: @user_collections %>
   </div>
 
-  <% if  params[:action] == "edit" %>
-  <div class="batch-toggle">
-     <% session[:batch_edit_state] = "on" %>
-    <%= button_for_remove_selected_from_collection @presenter %>
-   </div>
-  <%end %>
-   <div class="sort-toggle">
-     <%-# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {:action=>"index"} but I'm not sure -%>
-     <% unless @response.response['numFound'] < 2 %>
-        <%= form_tag collections.collection_path(@presenter), method: :get, class: 'per_page form-inline' do %>
-          <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
-          <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>
-          &nbsp;&nbsp;&nbsp;
-          <%= label_tag(:per_page) do %>
-            Show <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %> per page
-            <% end %>
-            <%= render_hash_as_hidden_fields(params_for_search.except(:per_page, :sort)) %>
-            &nbsp;&nbsp;&nbsp;
-            <button class="btn btn-primary"><i class="icon-refresh"></i> Refresh</button>
-            <%= render 'view_type_group' %>
-         <% end %>
-      <% end unless sort_fields.empty? %>
+  <% if action_name == "edit" %>
+    <div class="batch-toggle">
+      <% session[:batch_edit_state] = "on" %>
+      <%= button_for_remove_selected_from_collection collection %>
+    </div>
+  <% end %>
+  <div class="sort-toggle">
+    <%-# kind of hacky way to get this to work on catalog and folder controllers.  May be able to simple do {:action=>"index"} but I'm not sure -%>
+    <% unless @response.response['numFound'] < 2 %>
+      <%= form_tag collections.collection_path(collection), method: :get, class: 'per_page form-inline' do %>
+        <%= label_tag :sort do %>
+          <span>Sort By:</span>
+        <% end %>
+        <%= select_tag :sort, options_for_select(sort_fields, h(params[:sort])) %>
+        &nbsp;&nbsp;&nbsp;
+        <%= label_tag :per_page do %>
+          Show <%= select_tag :per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page" %> per page
+        <% end %>
+        <%= render_hash_as_hidden_fields params_for_search.except(:per_page, :sort) %>
+        &nbsp;&nbsp;&nbsp;
+        <button class="btn btn-primary"><i class="icon-refresh"></i> Refresh</button>
+        <%= render 'view_type_group' %>
+      <% end %>
+    <% end unless sort_fields.empty? %>
    </div>
 </div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 
 <%= render 'search_form' %>
-<%= render 'sort_and_per_page' %>
+<%= render 'sort_and_per_page', collection: @presenter %>
 
 <% if has_collection_search_parameters? %>
   <h2>Search Results within this Collection</h2>

--- a/spec/views/collections/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/collections/_sort_and_per_page.html.erb_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'collections/_sort_and_per_page.html.erb' do
+  let(:collection) { double }
+  let(:response) { double(response: { 'numFound' => 3 }) }
+
+  before do
+    allow(view).to receive(:sort_fields).and_return(['title_sort', 'date_sort'])
+    allow(view).to receive(:document_index_views).and_return(list: Blacklight::Configuration::ViewConfig.new)
+    assign(:response, response)
+  end
+
+  context "when the action is edit" do
+    before do
+      controller.action_name = "edit"
+    end
+    it "renders the form with a button" do
+      expect(view).to receive(:button_for_remove_selected_from_collection).with(collection)
+      render 'collections/sort_and_per_page', collection: collection
+    end
+  end
+
+  context "when the action is show" do
+    before do
+      controller.action_name = "show"
+    end
+    it "renders the form without a button" do
+      expect(view).not_to receive(:button_for_remove_selected_from_collection)
+      render 'collections/sort_and_per_page', collection: collection
+    end
+  end
+end


### PR DESCRIPTION
CurationConcerns currently only uses sort_and_per_page on the
Collection's show view. Sufia also uses it on the edit view. On the edit
view we use `@form` rather than `@presenter`, so replace the ivars with
local variables.