### PR TITLE
Simplify error handling in JSON

### DIFF
--- a/app/controllers/concerns/curation_concerns/api.rb
+++ b/app/controllers/concerns/curation_concerns/api.rb
@@ -4,22 +4,11 @@ module CurationConcerns
 
     def self.generate_response_body(response_type: :success, message: nil, options: {})
       json_body = default_responses[response_type].merge(options)
-      json_body[:description] = message if message && !messages_to_override.include?(message)
+      json_body[:description] = message if message
       json_body
     end
 
-    # Messages that should be overridden by defaults from locale file
-    # ie. exception messages from CanCan::AccessDenied
-
-    def self.messages_to_override
-      [
-        'You are not authorized to access this page.',
-        'ActiveFedora::ObjectNotFoundError'
-      ]
-    end
-
     # Default (json) responses for various response types
-
     def self.default_responses
       {
         success: {

--- a/app/controllers/concerns/curation_concerns/application_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/application_controller_behavior.rb
@@ -7,16 +7,20 @@ module CurationConcerns
     included do
       helper CurationConcerns::MainAppHelpers
 
-      rescue_from ActiveFedora::ObjectNotFoundError do |exception|
+      rescue_from ActiveFedora::ObjectNotFoundError do |_exception|
         respond_to do |wants|
           wants.html { render file: "#{Rails.root}/public/404", format: :html, status: :not_found, layout: false }
-          wants.json { render_json_response(response_type: :not_found, message: exception.message) }
+          wants.json { render_json_response(response_type: :not_found) }
         end
       end
     end
 
     # Called by Hydra::Controller::ControllerBehavior when CanCan::AccessDenied is caught
+    # @param [CanCan::AccessDenied] exception error to handle
     def deny_access(exception)
+      # For the JSON message, we don't want to display the default CanCan messages,
+      # just custom Hydra messages such as "This item is under embargo.", etc.
+      json_message = exception.message if exception.is_a? Hydra::AccessDenied
       if current_user && current_user.persisted?
         respond_to do |wants|
           wants.html do
@@ -26,13 +30,13 @@ module CurationConcerns
               redirect_to main_app.root_url, alert: exception.message
             end
           end
-          wants.json { render_json_response(response_type: :forbidden, message: exception.message) }
+          wants.json { render_json_response(response_type: :forbidden, message: json_message) }
         end
       else
         session['user_return_to'.freeze] = request.url
         respond_to do |wants|
           wants.html { redirect_to main_app.new_user_session_path, alert: exception.message }
-          wants.json { render_json_response(response_type: :unauthorized, message: exception.message) }
+          wants.json { render_json_response(response_type: :unauthorized, message: json_message) }
         end
       end
     end

--- a/spec/controllers/curation_concerns/file_sets_controller_json_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_json_spec.rb
@@ -24,6 +24,7 @@ describe CurationConcerns::FileSetsController do
       end
       it { is_expected.to respond_unauthorized }
     end
+
     describe "forbidden" do
       before do
         sign_in create(:user)
@@ -31,9 +32,10 @@ describe CurationConcerns::FileSetsController do
       end
       it { is_expected.to respond_forbidden }
     end
+
     describe 'not found' do
       before { get :show, id: "non-existent-pid", format: :json }
-      it { is_expected.to respond_not_found(description: 'Object non-existent-pid not found in solr') }
+      it { is_expected.to respond_not_found(description: 'Could not find a resource that matches your request.') }
     end
 
     describe 'created' do
@@ -53,14 +55,17 @@ describe CurationConcerns::FileSetsController do
         expect(response.location).to eq main_app.curation_concerns_file_set_path(created_resource)
       end
     end
+
     describe 'failed create: no file' do
       before { post :create, file_set: { title: ["foo"] }, parent_id: parent.id, format: :json }
       it { is_expected.to respond_bad_request(message: 'Error! No file to save') }
     end
+
     describe 'failed create: bad file' do
       before { post :create, file_set: { files: ['not a file'] }, parent_id: parent.id, format: :json }
       it { is_expected.to respond_bad_request(message: 'Error! No file for upload', description: 'unknown file') }
     end
+
     describe 'failed create: empty file' do
       before { post :create, file_set: { files: [empty_file] }, parent_id: parent.id, format: :json }
       it { is_expected.to respond_unprocessable_entity(errors: { files: "#{empty_file.original_filename} has no content! (Zero length file)" }, description: I18n.t('curation_concerns.api.unprocessable_entity.empty_file')) }
@@ -83,6 +88,7 @@ describe CurationConcerns::FileSetsController do
         expect(response.code).to eq "200"
       end
     end
+
     describe 'updated' do
       before { put :update, id: resource, file_set: { title: ['updated title'] }, format: :json }
       it "returns json of updated work and sets location header" do
@@ -93,6 +99,7 @@ describe CurationConcerns::FileSetsController do
         expect(response.location).to eq main_app.curation_concerns_file_set_path(created_resource)
       end
     end
+
     describe 'failed update' do
       before {
         expect(controller).to receive(:update_metadata) do


### PR DESCRIPTION
@tpendragon @escowles @jpstroop This is going to have a failure. I wonder how much you care about the existing behavior in this case:

```
       expected 404 status code. Got 404 status code.
       expected an Authentication Required response like this:
        {"code":404,"message":"Resource not found","description":"Object non-existent-pid not found in solr"}
       got
        {"code":404,"message":"Resource not found","description":"Could not find a resource that matches your request."}
       To override expectations about the response body, provide a Hash of overrides in your call to :respond_not_found

# spec/controllers/curation_concerns/file_sets_controller_json_spec.rb:36
```