### PR TITLE
Use NullLogger in case ActiveFedora::Base.logger is nil

### DIFF
--- a/curation_concerns-models/app/jobs/audit_job.rb
+++ b/curation_concerns-models/app/jobs/audit_job.rb
@@ -46,7 +46,9 @@ class AuditJob < ActiveFedoraIdBasedJob
       ChecksumAuditLog.create!(pass: passing, file_set_id: id, version: uri, file_id: file_id)
     end
 
+  private
+
     def logger
-      ActiveFedora::Base.logger
+      ActiveFedora::Base.logger || CurationConcerns::NullLogger.new
     end
 end

--- a/curation_concerns-models/lib/curation_concerns/models.rb
+++ b/curation_concerns-models/lib/curation_concerns/models.rb
@@ -11,6 +11,7 @@ module CurationConcerns
   autoload :Utils, 'curation_concerns/models/utils'
   autoload :Permissions
   autoload :Messages
+  autoload :NullLogger
   eager_autoload do
     autoload :Configuration
     autoload :Name

--- a/curation_concerns-models/lib/curation_concerns/null_logger.rb
+++ b/curation_concerns-models/lib/curation_concerns/null_logger.rb
@@ -1,0 +1,10 @@
+module CurationConcerns
+  class NullLogger < Logger
+    def initialize(*args)
+    end
+
+    # allows all the usual logger method calls (warn, info, error, etc.)
+    def add(*args, &block)
+    end
+  end
+end

--- a/spec/lib/curation_concerns/null_logger_spec.rb
+++ b/spec/lib/curation_concerns/null_logger_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe CurationConcerns::NullLogger do
+  subject { described_class.new }
+  its(:debug) { is_expected.to be_nil }
+  its(:info) { is_expected.to be_nil }
+  its(:warn) { is_expected.to be_nil }
+  its(:error) { is_expected.to be_nil }
+  its(:fatal) { is_expected.to be_nil }
+end


### PR DESCRIPTION
`ActiveFedora::Base.logger` can be nil, so provide a null object to stand in its place that accepts all the same methods as a logger, but just returns nil. This has additional uses in other dependent gems that might send logging messages to nil objects such as `Rails.logger`.