### PR TITLE
Delegates a few more calls to SolrDocument...

### DIFF
--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -21,7 +21,8 @@ module CurationConcerns
     # Metadata Methods
     delegate :title, :description, :creator, :contributor, :subject, :publisher,
              :language, :date_uploaded, :rights,
-             :embargo_release_date, :lease_expiration_date, to: :solr_document
+             :embargo_release_date, :lease_expiration_date,
+             :depositor, :tags, to: :solr_document
 
     def page_title
       Array(solr_document['label_tesim']).first

--- a/spec/presenters/curation_concerns/file_set_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/file_set_presenter_spec.rb
@@ -50,6 +50,20 @@ describe CurationConcerns::FileSetPresenter do
     end
   end
 
+  describe "depositor" do
+    it "delegates to the solr_document" do
+      expect(solr_document).to receive(:depositor)
+      presenter.depositor
+    end
+  end
+
+  describe "tags" do
+    it "delegates to the solr_document" do
+      expect(solr_document).to receive(:tags)
+      presenter.tags
+    end
+  end
+
   describe "fetch" do
     it "delegates to the solr_document" do
       expect(solr_document).to receive(:fetch).and_call_original


### PR DESCRIPTION
...so that we can access the `tags` and `depositor` properties