### PR TITLE
Delegate title_or_label from the FileSetPresenter to the SolrDocument

### DIFF
--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -22,7 +22,7 @@ module CurationConcerns
     delegate :title, :description, :creator, :contributor, :subject, :publisher,
              :language, :date_uploaded, :rights,
              :embargo_release_date, :lease_expiration_date,
-             :depositor, :tags, to: :solr_document
+             :depositor, :tags, :title_or_label, to: :solr_document
 
     def page_title
       Array(solr_document['label_tesim']).first

--- a/spec/presenters/curation_concerns/file_set_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/file_set_presenter_spec.rb
@@ -43,24 +43,17 @@ describe CurationConcerns::FileSetPresenter do
     it { is_expected.to eq 'File Set' }
   end
 
-  describe "date_uploaded" do
-    it "delegates to the solr_document" do
-      expect(solr_document).to receive(:date_uploaded)
-      presenter.date_uploaded
+  describe "properties delegated to solr_document" do
+    let(:solr_properties) do
+      ["date_uploaded", "depositor", "tags", "title_or_label",
+       "contributor", "creator", "title", "description", "publisher",
+       "subject", "language", "rights"]
     end
-  end
-
-  describe "depositor" do
     it "delegates to the solr_document" do
-      expect(solr_document).to receive(:depositor)
-      presenter.depositor
-    end
-  end
-
-  describe "tags" do
-    it "delegates to the solr_document" do
-      expect(solr_document).to receive(:tags)
-      presenter.tags
+      solr_properties.each do |property|
+        expect(solr_document).to receive(property.to_sym)
+        presenter.send(property)
+      end
     end
   end
 


### PR DESCRIPTION
@awead As you suggested, here is the PR with some of the missing properties in the presenter.

Adds `title_or_label` to the presenter.

Document in the test other properties that should also be delegated. See TODO in the test.

Waiting on feedback from the team at the daily. 