### PR TITLE
Port over projecthydra/sufia@7a7b25c92e94a531aa7bddd1c84883effa1f9f91

### DIFF
--- a/curation_concerns-models/app/indexers/curation_concerns/file_set_indexing_service.rb
+++ b/curation_concerns-models/app/indexers/curation_concerns/file_set_indexing_service.rb
@@ -18,7 +18,18 @@ module CurationConcerns
         solr_doc['width_is'] = Integer(object.width.first) if object.width.present?
         solr_doc[Solrizer.solr_name('mime_type', :stored_sortable)] = object.mime_type
         solr_doc['thumbnail_path_ss'] = thumbnail_path
+        # Index the Fedora-generated SHA1 digest to create a linkage
+        # between files on disk (in fcrepo.binary-store-path) and objects
+        # in the repository.
+        solr_doc[Solrizer.solr_name('digest', :symbol)] = digest_from_content
       end
     end
+
+    private
+
+      def digest_from_content
+        return unless object.original_file
+        object.original_file.digest.first.to_s
+      end
   end
 end

--- a/curation_concerns-models/app/models/concerns/curation_concerns/file_set/querying.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/file_set/querying.rb
@@ -1,0 +1,17 @@
+module CurationConcerns
+  module FileSet
+    module Querying
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def where_digest_is(digest_string)
+          where Solrizer.solr_name('digest', :symbol) => urnify(digest_string)
+        end
+
+        def urnify(digest_string)
+          "urn:sha1:#{digest_string}"
+        end
+      end
+    end
+  end
+end

--- a/curation_concerns-models/app/models/concerns/curation_concerns/file_set_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/file_set_behavior.rb
@@ -14,6 +14,7 @@ module CurationConcerns
     include CurationConcerns::FileSet::Indexing
     include CurationConcerns::FileSet::BelongsToWorks
     include CurationConcerns::FileSet::BelongsToUploadSets
+    include CurationConcerns::FileSet::Querying
     include CurationConcerns::HumanReadableType
     include CurationConcerns::Naming
     include Hydra::AccessControls::Embargoable

--- a/spec/indexers/file_set_indexing_service_spec.rb
+++ b/spec/indexers/file_set_indexing_service_spec.rb
@@ -28,10 +28,18 @@ describe CurationConcerns::FileSetIndexingService do
       end
   end
 
+  let(:mock_file) do
+    mock_model("MockFile",
+               content: "asdf",
+               digest: ["urn:sha1:f794b23c0c6fe1083d0ca8b58261a078cd968967"]
+              )
+  end
+
   describe '#generate_solr_document' do
     before do
       allow(file_set).to receive(:label).and_return('CastoriaAd.tiff')
       allow(CurationConcerns::ThumbnailPathService).to receive(:call).and_return('/downloads/foo123?file=thumbnail')
+      allow(file_set).to receive(:original_file).and_return(mock_file)
     end
     subject { described_class.new(file_set).generate_solr_document }
 
@@ -64,6 +72,7 @@ describe CurationConcerns::FileSetIndexingService do
       expect(subject['all_text_timv']).to eq('abcxyz')
       expect(subject['height_is']).to eq 500
       expect(subject['width_is']).to eq 600
+      expect(subject[Solrizer.solr_name('digest', :symbol)]).to eq 'urn:sha1:f794b23c0c6fe1083d0ca8b58261a078cd968967'
     end
   end
 end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -361,6 +361,21 @@ describe FileSet do
     end
   end
 
+  describe '#where_digest_is' do
+    let(:file) { create(:file_set) }
+    let(:file_path) { fixture_path + '/small_file.txt' }
+    let(:digest_string) { '88fb4e88c15682c18e8b19b8a7b6eaf8770d33cf' }
+    before do
+      allow(file).to receive(:warn) # suppress virus warnings
+      of = file.build_original_file
+      of.content = File.open(file_path)
+      file.save
+      file.update_index
+    end
+    subject { described_class.where_digest_is(digest_string).first }
+    it { is_expected.to eq(file) }
+  end
+
   describe 'to_solr' do
     let(:indexer) { double(generate_solr_document: {}) }
     before do


### PR DESCRIPTION
Index Fedora digest to link NRSes on disk to findable objects.
Provide a query method that knows how to convert a digest string into a URN. Fixes #493