### PR TITLE
DON'T MERGE: Fixes the link being wider than the image

### DIFF
--- a/app/assets/stylesheets/curation_concerns/_curation_concerns.scss
+++ b/app/assets/stylesheets/curation_concerns/_curation_concerns.scss
@@ -10,3 +10,4 @@
 @import "curation_concerns/typography";
 @import 'hydra-editor/multi_value_fields';
 @import 'curation_concerns/fileupload';
+@import 'curation_concerns/responsive';

--- a/app/assets/stylesheets/curation_concerns/_responsive.scss
+++ b/app/assets/stylesheets/curation_concerns/_responsive.scss
@@ -1,0 +1,3 @@
+.img-link-responsive  {
+  display: inline-block;
+}

--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -1,4 +1,4 @@
   <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the document" do %>
-    <%= image_tag "default.png", alt: "No preview available", class: "img-responsive" %>
+    <%= image_tag "default.png", alt: "No preview available", class: "img-link-responsive" %>
   <% end %>
 

--- a/app/views/curation_concerns/file_sets/media_display/_image.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_image.html.erb
@@ -1,6 +1,6 @@
    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the full-sized image" do %>
      <%= image_tag(main_app.download_path(file_set, file: 'thumbnail'),
-                   class: "img-responsive",
+                   class: "img-link-responsive",
                    alt: "Download the full-sized image of #{file_set.to_s}"
                   ) %>
      Download the full-sized image

--- a/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
@@ -1,6 +1,6 @@
    <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the document" do %>
      <%= image_tag(main_app.download_path(file_set, file: 'thumbnail'),
-                   class: "img-responsive",
+                   class: "img-link-responsive",
                    alt: "Download the document \"#{file_set.to_s}\""
                   ) %>
      Download the document

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -1,6 +1,6 @@
   <%= link_to main_app.download_path(file_set), target: "_new", title: "Download the full-sized PDF" do%>
     <%= image_tag main_app.download_path(file_set, file: 'thumbnail'),
-                  class: "img-responsive",
+                  class: "img-link-responsive",
                   alt: "Download the full-sized PDF of #{file_set.to_s}" %>
     Download the full-sized PDF
   <% end %>


### PR DESCRIPTION
Fixes the link being wider than the image if the browser window is expanded. In order to just have the link wrap the intrinsic value of the image, switch img-responsive to inline block. Fixes #496