### PR TITLE
Fixes #505 use ported rails auto_link to create links in attribute value

### DIFF
--- a/app/renderers/curation_concerns/attribute_renderer.rb
+++ b/app/renderers/curation_concerns/attribute_renderer.rb
@@ -1,7 +1,11 @@
+require "rails_autolink/helpers"
+
 module CurationConcerns
   class AttributeRenderer
     include ActionView::Helpers::UrlHelper
     include ActionView::Helpers::TranslationHelper
+    include ActionView::Helpers::TextHelper
+
     attr_reader :field, :values, :options
 
     # @param [Symbol] field
@@ -47,8 +51,11 @@ module CurationConcerns
       end
 
       def li_value(value)
-        link_to_if(options[:catalog_search_link], ERB::Util.h(value),
-                   search_path(value))
+        if options[:catalog_search_link]
+          link_to(ERB::Util.h(value), search_path(value))
+        else
+          auto_link(value)
+        end
       end
 
       def search_path(value)

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'curation_concerns-models', version
   spec.add_dependency 'hydra-editor', '~> 1.1'
   spec.add_dependency 'blacklight_advanced_search', ['>= 5.1.4', '< 6.0']
+  spec.add_dependency 'rails_autolink'
 
   spec.add_development_dependency "devise", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
@@ -4,14 +4,17 @@ describe 'curation_concerns/base/_attributes.html.erb' do
   let(:creator)     { 'Bilbo' }
   let(:contributor) { 'Frodo' }
   let(:subject)     { 'history' }
+  let(:description) { ['Lorem ipsum lorem ipsum. http://my.link.com'] }
 
   let(:solr_document) { SolrDocument.new(subject_tesim: subject,
                                          contributor_tesim: contributor,
-                                         creator_tesim: creator) }
+                                         creator_tesim: creator,
+                                         description_tesim: description) }
   let(:ability) { nil }
   let(:presenter) do
     CurationConcerns::WorkShowPresenter.new(solr_document, ability)
   end
+  let(:doc) { Nokogiri::HTML(rendered) }
 
   before do
     allow(view).to receive(:dom_class) { '' }
@@ -24,5 +27,9 @@ describe 'curation_concerns/base/_attributes.html.erb' do
     expect(rendered).to have_link(creator, href: catalog_index_path(search_field: 'creator', q: creator))
     expect(rendered).to have_link(contributor, href: catalog_index_path(search_field: 'contributor', q: contributor))
     expect(rendered).to have_link(subject, href: catalog_index_path(search_field: 'subject', q: subject))
+  end
+  it 'shows links in the description' do
+    a1 = doc.xpath("//li[@class='attribute description']/a").text
+    expect(a1).to start_with 'http://my.link.com'
   end
 end


### PR DESCRIPTION
Uses a port of Rails 3 auto_link texthelper to insert links into attribute values when there isa url in the value, but it is not being linked to a catalog search.