### PR TITLE
Collection size from solr instead of fedora.

### DIFF
--- a/app/presenters/curation_concerns/collection_presenter.rb
+++ b/app/presenters/curation_concerns/collection_presenter.rb
@@ -2,6 +2,7 @@ module CurationConcerns
   class CollectionPresenter
     include ModelProxy
     include PresentsAttributes
+    include ActionView::Helpers::NumberHelper
     attr_accessor :solr_document, :current_ability
 
     # @param [SolrDocument] solr_document
@@ -18,5 +19,13 @@ module CurationConcerns
     # Metadata Methods
     delegate :title, :description, :creator, :contributor, :subject, :publisher, :language,
              :embargo_release_date, :lease_expiration_date, :rights, to: :solr_document
+
+    def size
+      number_to_human_size(@solr_document['bytes_is'])
+    end
+
+    def total_items
+      @solr_document['member_ids_ssim'].length
+    end
   end
 end

--- a/curation_concerns-models/app/indexers/curation_concerns/collection_indexer.rb
+++ b/curation_concerns-models/app/indexers/curation_concerns/collection_indexer.rb
@@ -1,9 +1,12 @@
 module CurationConcerns
   class CollectionIndexer < Hydra::PCDM::CollectionIndexer
+    STORED_INTEGER = Solrizer::Descriptor.new(:integer, :stored)
     def generate_solr_document
       super.tap do |solr_doc|
         # Makes Collections show under the "Collections" tab
         Solrizer.set_field(solr_doc, 'generic_type', 'Collection', :facetable)
+        # Index the size of the collection in bytes
+        solr_doc[Solrizer.solr_name(:bytes, STORED_INTEGER)] = object.bytes
       end
     end
   end

--- a/curation_concerns-models/app/indexers/curation_concerns/file_set_indexing_service.rb
+++ b/curation_concerns-models/app/indexers/curation_concerns/file_set_indexing_service.rb
@@ -1,6 +1,7 @@
 module CurationConcerns
   class FileSetIndexingService < ActiveFedora::IndexingService
     include IndexesThumbnails
+    STORED_INTEGER = Solrizer::Descriptor.new(:integer, :stored)
 
     def generate_solr_document
       super.tap do |solr_doc|
@@ -11,7 +12,7 @@ module CurationConcerns
         solr_doc[Solrizer.solr_name('label', :stored_sortable)] = object.label
         solr_doc[Solrizer.solr_name('file_format')] = object.file_format
         solr_doc[Solrizer.solr_name('file_format', :facetable)] = object.file_format
-        solr_doc[Solrizer.solr_name(:file_size, :symbol)] = object.file_size[0]
+        solr_doc[Solrizer.solr_name(:file_size, STORED_INTEGER)] = object.file_size[0]
         solr_doc['all_text_timv'] = object.full_text.content
         solr_doc[Solrizer.solr_name('generic_work_ids', :symbol)] = object.generic_work_ids unless object.generic_work_ids.empty?
         solr_doc['height_is'] = Integer(object.height.first) if object.height.present?

--- a/curation_concerns-models/app/models/concerns/curation_concerns/collection_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/collection_behavior.rb
@@ -23,10 +23,6 @@ module CurationConcerns
       title.present? ? title : 'No Title'
     end
 
-    def bytes
-      members.reduce(0) { |sum, gf| sum + gf.content.size.to_i }
-    end
-
     def can_be_member_of_collection?(collection)
       collection != self
     end
@@ -37,7 +33,41 @@ module CurationConcerns
       end
     end
 
+    # Compute the sum of each file in the collection using Solr to
+    # avoid having to access Fedora
+    #
+    # @return [Fixnum] size of collection in bytes
+    # @raise [RuntimeError] unsaved record does not exist in solr
+    def bytes
+      return 0 if member_ids.count == 0
+
+      raise "Collection must be saved to query for bytes" if new_record?
+
+      # One query per member_id because Solr is not a relational database
+      sizes = member_ids.collect do |work_id|
+        query = ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::FileSet.to_class_uri)
+        argz = { fl: "id, #{file_size_field}",
+                 fq: "{!join from=#{member_ids_field} to=id}id:#{work_id}"
+        }
+        files = ActiveFedora::SolrService.query(query, argz)
+        files.reduce(0) { |sum, f| sum + f[file_size_field].to_i }
+      end
+
+      sizes.reduce(0, :+)
+    end
+
     private
+
+      # Field name to look up when locating the size of each file in Solr.
+      # Override for your own installation if using something different
+      def file_size_field
+        Solrizer.solr_name(:file_size, FileSetIndexingService::STORED_INTEGER)
+      end
+
+      # Solr field name collections and works use to index member ids
+      def member_ids_field
+        Solrizer.solr_name('member_ids', :symbol)
+      end
 
       def can_add_to_members?(collectible)
         collectible.try(:can_be_member_of_collection?, self)

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -24,6 +24,7 @@ FactoryGirl.define do
         FactoryGirl.create(:generic_work, user: evaluator.user).members << file
       end
     end
+
     after(:build) do |file, evaluator|
       file.apply_depositor_metadata(evaluator.user.user_key)
     end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -26,6 +26,7 @@ FactoryGirl.define do
     factory :work_with_files do
       before(:create) { |work, evaluator| 2.times { work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user) } }
     end
+
     factory :work_with_ordered_files do
       before(:create) do |work, evaluator|
         work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user)

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -4,11 +4,16 @@ describe CurationConcerns::CollectionIndexer do
   let(:indexer) { described_class.new(collection) }
   let(:collection) { build(:collection) }
 
+  before { allow(collection).to receive(:bytes).and_return(1000) }
   describe "#generate_solr_document" do
     subject { indexer.generate_solr_document }
 
     it "has generic type" do
       expect(subject.fetch('generic_type_sim')).to eq ["Collection"]
+    end
+
+    it "has bytes" do
+      expect(subject.fetch('bytes_is')).to eq(1000)
     end
   end
 end

--- a/spec/presenters/curation_concerns/collection_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/collection_presenter_spec.rb
@@ -2,9 +2,13 @@ require 'spec_helper'
 
 describe CurationConcerns::CollectionPresenter do
   let(:collection) { Collection.new(id: 'adc12v', description: 'a nice collection', title: 'A clever title') }
+  let(:work) { FactoryGirl.build(:work, title: ['unimaginitive title']) }
   let(:solr_document) { SolrDocument.new(collection.to_solr) }
   let(:ability) { double }
   let(:presenter) { described_class.new(solr_document, ability) }
+
+  # Mock bytes so collection does not have to be saved.
+  before { allow(collection).to receive(:bytes).and_return(0) }
 
   describe '#title' do
     subject { presenter.title }
@@ -14,5 +18,21 @@ describe CurationConcerns::CollectionPresenter do
   describe '#to_key' do
     subject { presenter.to_key }
     it { is_expected.to eq ['adc12v'] }
+  end
+
+  describe "#size" do
+    subject { presenter.size }
+    it { is_expected.to eq '0 Bytes' }
+  end
+
+  describe "#total_items" do
+    subject { presenter.total_items }
+    context "empty collection" do
+      it { is_expected.to eq 0 }
+    end
+    context "collection with work" do
+      before { collection.members << work }
+      it { is_expected.to eq 1 }
+    end
   end
 end


### PR DESCRIPTION
Working towards getting the size in bytes of the collection indexed in Solr so one doesn't have to load all the items from Fedora.