### PR TITLE
Rename *IndexingService to *Indexer

### DIFF
--- a/curation_concerns-models/app/indexers/curation_concerns/file_set_indexer.rb
+++ b/curation_concerns-models/app/indexers/curation_concerns/file_set_indexer.rb
@@ -1,5 +1,5 @@
 module CurationConcerns
-  class FileSetIndexingService < ActiveFedora::IndexingService
+  class FileSetIndexer < ActiveFedora::IndexingService
     include IndexesThumbnails
     STORED_INTEGER = Solrizer::Descriptor.new(:integer, :stored)
 

--- a/curation_concerns-models/app/indexers/curation_concerns/work_indexer.rb
+++ b/curation_concerns-models/app/indexers/curation_concerns/work_indexer.rb
@@ -1,5 +1,5 @@
 module CurationConcerns
-  class WorkIndexingService < ActiveFedora::IndexingService
+  class WorkIndexer < ActiveFedora::IndexingService
     include IndexesThumbnails
     def generate_solr_document
       super.tap do |solr_doc|

--- a/curation_concerns-models/app/models/concerns/curation_concerns/collection_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/collection_behavior.rb
@@ -61,7 +61,7 @@ module CurationConcerns
       # Field name to look up when locating the size of each file in Solr.
       # Override for your own installation if using something different
       def file_size_field
-        Solrizer.solr_name(:file_size, FileSetIndexingService::STORED_INTEGER)
+        Solrizer.solr_name(:file_size, FileSetIndexer::STORED_INTEGER)
       end
 
       # Solr field name collections and works use to index member ids

--- a/curation_concerns-models/app/models/concerns/curation_concerns/file_set/indexing.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/file_set/indexing.rb
@@ -6,7 +6,7 @@ module CurationConcerns
       module ClassMethods
         # override the default indexing service
         def indexer
-          CurationConcerns::FileSetIndexingService
+          CurationConcerns::FileSetIndexer
         end
       end
     end

--- a/curation_concerns-models/app/models/concerns/curation_concerns/work_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/work_behavior.rb
@@ -21,7 +21,7 @@ module CurationConcerns::WorkBehavior
 
   module ClassMethods
     def indexer
-      CurationConcerns::WorkIndexingService
+      CurationConcerns::WorkIndexer
     end
   end
 

--- a/spec/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/file_set_indexer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CurationConcerns::FileSetIndexingService do
+describe CurationConcerns::FileSetIndexer do
   let(:file_set) do
     FileSet.new(
       id: 'foo123',

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CurationConcerns::WorkIndexingService do
+describe CurationConcerns::WorkIndexer do
   # TODO: file_set_ids returns an empty set unless you persist the work
   let(:user) { create(:user) }
   let!(:generic_work) { create(:work_with_one_file, user: user) }

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -147,7 +147,7 @@ describe FileSet do
 
   describe '#indexer' do
     subject { described_class.indexer }
-    it { is_expected.to eq CurationConcerns::FileSetIndexingService }
+    it { is_expected.to eq CurationConcerns::FileSetIndexer }
   end
 
   it 'supports multi-valued fields in solr' do
@@ -379,7 +379,7 @@ describe FileSet do
   describe 'to_solr' do
     let(:indexer) { double(generate_solr_document: {}) }
     before do
-      allow(CurationConcerns::FileSetIndexingService).to receive(:new)
+      allow(CurationConcerns::FileSetIndexer).to receive(:new)
         .with(subject).and_return(indexer)
     end
 

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -25,7 +25,7 @@ describe GenericWork do
 
   describe '#indexer' do
     subject { described_class.indexer }
-    it { is_expected.to eq CurationConcerns::WorkIndexingService }
+    it { is_expected.to eq CurationConcerns::WorkIndexer }
   end
 
   describe 'to_solr' do


### PR DESCRIPTION
The "Service" part of the name doesn't add anything to our understanding
of what the class does. Fixes #527