### PR TITLE
pass presenter as a local variable

### DIFF
--- a/app/views/curation_concerns/file_sets/upload/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_for(FileSet.new, url: main_app.curation_concerns_file_sets_path(parent_id: @presenter.id), html: { multipart: true, id: 'fileupload' }) do |f| %>
   <div class="well">
-    <%= render partial: 'curation_concerns/file_sets/upload/form_fields', presenter: @presenter, locals: { upload_set_id: ActiveFedora::Noid::Service.new.mint } %>
+    <%= render 'curation_concerns/file_sets/upload/form_fields', presenter: @presenter, upload_set_id: ActiveFedora::Noid::Service.new.mint %>
   </div>
 <% end %>
 


### PR DESCRIPTION
Since `partial` was supplied, presenter was considered a custom argument
to render and not a local variable.