### PR TITLE
Use data-toggle attribute for declaring popover

### DIFF
--- a/curation_concerns-models/lib/curation_concerns/messages.rb
+++ b/curation_concerns-models/lib/curation_concerns/messages.rb
@@ -40,9 +40,9 @@ module CurationConcerns
     end
 
     # Double-quotes are replaced with single ones so this list can be included in a data block. Ex:
-    #   <a href="#" data-content="<a href='#'>embedded link</a>" rel="popover">Click me</a>
+    #   <a href="#" data-content="<a href='#'>embedded link</a>" data-toggle="popover">Click me</a>
     def file_list(files)
-      files.map { |gf| link_to_file(gf) }.join(', ').tr("\"", "'")
+      files.map { |fs| link_to_file(fs) }.join(', ').tr("\"", "'")
     end
 
     def link_to_file(file)
@@ -53,14 +53,16 @@ module CurationConcerns
 
       def success_link(files)
         link_to I18n.t('curation_concerns.messages.success.multiple.link'), '#',
-                rel: 'popover',
-                data: { content: file_list(files).html_safe, title: I18n.t('curation_concerns.messages.success.title') }
+                data: { toggle: 'popover',
+                        content: file_list(files).html_safe,
+                        title: I18n.t('curation_concerns.messages.success.title') }
       end
 
       def failure_link(files)
         link_to I18n.t('curation_concerns.messages.failure.multiple.link'), '#',
-                rel: 'popover',
-                data: { content: file_list(files).html_safe, title: I18n.t('curation_concerns.messages.failure.title') }
+                data: { toggle: 'popover',
+                        content: file_list(files).html_safe,
+                        title: I18n.t('curation_concerns.messages.failure.title') }
       end
   end
 end

--- a/spec/lib/curation_concerns/messages_spec.rb
+++ b/spec/lib/curation_concerns/messages_spec.rb
@@ -41,7 +41,7 @@ describe CurationConcerns::Messages do
     it 'renders a success message for multiple files' do
       node = Capybara::Node::Simple.new(message.multiple_success(upload_set_id, multiple))
       expect(node).to have_selector("span[id=\"ss-1\"]", text: 'These files have been saved.')
-      expect(node).to have_selector("a[data-content=\"#{file_list}\"][rel=\"popover\"][data-title=\"Files uploaded successfully\"]")
+      expect(node).to have_selector("a[data-content=\"#{file_list}\"][data-toggle=\"popover\"][data-title=\"Files uploaded successfully\"]")
     end
   end
 
@@ -57,7 +57,7 @@ describe CurationConcerns::Messages do
     it 'renders a failure message for multiple files' do
       node = Capybara::Node::Simple.new(message.multiple_failure(upload_set_id, multiple))
       expect(node).to have_selector("span[id=\"ss-1\"]", text: 'These files could not be updated. You do not have sufficient privileges to edit them.')
-      expect(node).to have_selector("a[data-content=\"#{file_list}\"][rel=\"popover\"][data-title=\"Files failed\"]")
+      expect(node).to have_selector("a[data-content=\"#{file_list}\"][data-toggle=\"popover\"][data-title=\"Files failed\"]")
     end
   end
 


### PR DESCRIPTION
This is the usage recommended by the bootstrap docs, :speech_balloon: @jcoyne. Pulled from https://github.com/projecthydra-deprecated/sufia-core/pull/395