### PR TITLE
Handle image asset precompilation in the engine's initializers

### DIFF
--- a/lib/curation_concerns/engine.rb
+++ b/lib/curation_concerns/engine.rb
@@ -23,5 +23,11 @@ module CurationConcerns
     initializer 'curation_concerns.initialize' do
       require 'curation_concerns/rails/routes'
     end
+
+    initializer 'curation_concerns.assets.precompile' do |app|
+      app.config.assets.paths << config.root.join('app', 'assets', 'images')
+
+      app.config.assets.precompile += %w(*.png *.gif)
+    end
   end
 end

--- a/spec/services/thumbnail_path_service_spec.rb
+++ b/spec/services/thumbnail_path_service_spec.rb
@@ -15,11 +15,11 @@ describe CurationConcerns::ThumbnailPathService do
 
     context "that is an audio" do
       let(:mime_type) { 'audio/x-wav' }
-      it { is_expected.to eq '/assets/audio.png' }
+      it { is_expected.to match %r{/assets/audio-.+.png} }
     end
 
     context "that has no thumbnail" do
-      it { is_expected.to eq '/assets/default.png' }
+      it { is_expected.to match %r{/assets/default-.+.png} }
     end
   end
 
@@ -37,7 +37,7 @@ describe CurationConcerns::ThumbnailPathService do
 
     context "that doesn't have a representative" do
       let(:object) { FileSet.new }
-      it { is_expected.to eq '/assets/default.png' }
+      it { is_expected.to match %r{/assets/default-.+.png} }
     end
   end
 end


### PR DESCRIPTION
This is required by sprockets-rails 3.0.0. (Before this, the test suite was red with 60+ errors.)