### PR TITLE
Restore additional_response_formats for FileSets

### DIFF
--- a/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
@@ -61,6 +61,7 @@ module CurationConcerns
           authorize! :show, @file_set
           render :show, status: :ok
         end
+        additional_response_formats(wants)
       end
     end
 
@@ -138,6 +139,12 @@ module CurationConcerns
 
       def initialize_edit_form
         @groups = current_user.groups
+      end
+
+      # Override this method to add additional response
+      # formats to your local app
+      def additional_response_formats(_)
+        # nop
       end
 
       def file_set_params

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -222,6 +222,7 @@ describe CurationConcerns::FileSetsController do
       end
 
       it 'allows access to public files' do
+        expect(controller).to receive(:additional_response_formats).with(ActionController::MimeResponds::Collector)
         get :show, id: public_file_set
         expect(response).to be_success
       end


### PR DESCRIPTION
This behavior was lost in
https://github.com/projecthydra-labs/curation_concerns/commit/8feb86557614cd3d99983989a6946d395f96db67
but it is still in use by goldenseal to transform TEI into VTT files.