### PR TITLE
Remove a work removes the list source

### DIFF
--- a/curation_concerns-models/app/models/concerns/curation_concerns/with_file_sets.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/with_file_sets.rb
@@ -5,7 +5,7 @@ module CurationConcerns
 
     included do
       # The file_sets association and its accessor methods comes from Hydra::Works::AggregatesFileSets
-      before_destroy :before_destroy_cleanup_file_sets
+      before_destroy :cleanup_file_sets
     end
 
     # Stopgap unil ActiveFedora ContainerAssociation includes an *_ids accessor.
@@ -14,7 +14,11 @@ module CurationConcerns
       file_sets.map(&:id)
     end
 
-    def before_destroy_cleanup_file_sets
+    def cleanup_file_sets
+      # Destroy the list source first.  This prevents each file_set from attemping to
+      # remove itself individually from the work. If hundreds of files are attached,
+      # this would take too long.
+      list_source.destroy
       file_sets.each(&:destroy)
     end
 

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -46,4 +46,14 @@ describe GenericWork do
     subject { work.to_partial_path }
     it { is_expected.to eq 'generic_works/generic_work' }
   end
+
+  describe "#destroy" do
+    let!(:work) { create(:work_with_files) }
+    it "doesn't save the work after removing each individual file" do
+      expect_any_instance_of(described_class).not_to receive(:save!)
+      expect {
+        work.destroy
+      }.to change { FileSet.count }.by(-2)
+    end
+  end
 end


### PR DESCRIPTION
Prior to this change, the work was getting saved after each of its files
were removed. This means that for a work with many files, the operation was
taking way too long.