### PR TITLE
Specify full path to constant.

### DIFF
--- a/curation_concerns-models/app/models/concerns/curation_concerns/collection_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/collection_behavior.rb
@@ -61,7 +61,7 @@ module CurationConcerns
       # Field name to look up when locating the size of each file in Solr.
       # Override for your own installation if using something different
       def file_size_field
-        Solrizer.solr_name(:file_size, FileSetIndexer::STORED_INTEGER)
+        Solrizer.solr_name(:file_size, CurationConcerns::FileSetIndexer::STORED_INTEGER)
       end
 
       # Solr field name collections and works use to index member ids


### PR DESCRIPTION
If an application has FileSetIndexer defined, a `NameError` could be raised:

```
     NameError:
       uninitialized constant FileSetIndexer::STORED_INTEGER
```