### PR TITLE
Fixing bug in looking up parent_id

### DIFF
--- a/app/controllers/concerns/curation_concerns/parent_container.rb
+++ b/app/controllers/concerns/curation_concerns/parent_container.rb
@@ -22,7 +22,7 @@ module CurationConcerns::ParentContainer
   end
 
   def parent_id
-    @parent_id ||= new_or_create? ? params[:parent_id] : curation_concern.generic_works.in_objects.first.id
+    @parent_id ||= new_or_create? ? params[:parent_id] : lookup_parent_from_child.id
   end
 
   protected

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -235,4 +235,27 @@ describe CurationConcerns::FileSetsController do
       end
     end
   end
+
+  context 'finds parents' do
+    let(:file_set) do
+      file_set = FileSet.create! do |gf|
+        gf.apply_depositor_metadata(user)
+      end
+      parent.ordered_members << file_set
+      parent.save
+      file_set
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:curation_concern).and_return(file_set)
+    end
+
+    it 'finds a parent' do
+      expect(controller.parent).to eq(parent)
+    end
+
+    it 'finds a parent id' do
+      expect(controller.parent_id).to eq(parent.id)
+    end
+  end
 end


### PR DESCRIPTION
* using existing `lookup_parent_from_child` method to lookup parent instead of duplicating