### PR TITLE
Fix html escaping in AttributeRenderer

### DIFF
--- a/app/renderers/curation_concerns/attribute_renderer.rb
+++ b/app/renderers/curation_concerns/attribute_renderer.rb
@@ -70,7 +70,7 @@ module CurationConcerns
         if options[:catalog_search_link]
           link_to(ERB::Util.h(value), search_path(value))
         else
-          auto_link(value)
+          auto_link(ERB::Util.h(value))
         end
       end
 

--- a/spec/renderers/curation_concerns/attribute_renderer_spec.rb
+++ b/spec/renderers/curation_concerns/attribute_renderer_spec.rb
@@ -58,5 +58,17 @@ describe CurationConcerns::AttributeRenderer do
       it { expect(renderer).to be_microdata(field) }
       it { expect(subject).to be_equivalent_to(expected) }
     end
+
+    context 'with links and < characters' do
+      let(:field) { :description }
+      let(:renderer) { described_class.new(field, ['Foo < Bar http://www.example.com. & More Text']) }
+      let(:tr_content) do
+        "<tr><th>Description</th>\n" \
+         "<td><ul class='tabular'><li class=\"attribute description\"><span itemprop=\"description\">Foo &lt; Bar <a href=\"http://www.example.com\">http://www.example.com</a>. &amp; More Text</span></li>\n" \
+         "</ul></td></tr>"
+      end
+
+      it { expect(subject).to be_equivalent_to(expected) }
+    end
   end
 end

--- a/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe 'curation_concerns/base/_attributes.html.erb' do
   let(:creator)     { 'Bilbo' }
   let(:contributor) { 'Frodo' }
   let(:subject)     { 'history' }
-  let(:description) { ['Lorem ipsum lorem ipsum. http://my.link.com'] }
+  let(:description) { ['Lorem ipsum < lorem ipsum. http://my.link.com'] }
 
   let(:solr_document) { SolrDocument.new(subject_tesim: subject,
                                          contributor_tesim: contributor,


### PR DESCRIPTION
Fixes an issue with escaping in AttributeRenderer. See projecthydra/sufia#1546 which also affects CurationConcerns. In short, auto_link doesn't escape whatever you pass to it. If it gets something with a less than character, then it silently chops off the value at that point. If for example description is "foo < bar", then it would be rendered as just "foo" because auto_link eats the rest of it. 