### PR TITLE
add 'on_behalf_of' property for fileset

### DIFF
--- a/curation_concerns-models/app/models/concerns/curation_concerns/file_set/proxy_deposit.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/file_set/proxy_deposit.rb
@@ -1,0 +1,30 @@
+module CurationConcerns
+  module FileSet
+    module ProxyDeposit
+      extend ActiveSupport::Concern
+
+      included do
+        property :proxy_depositor, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#proxyDepositor'), multiple: false do |index|
+          index.as :symbol
+        end
+
+        # This value is set when a user indicates they are depositing this for someone else
+        property :on_behalf_of, predicate: ::RDF::URI.new('http://scholarsphere.psu.edu/ns#onBehalfOf'), multiple: false do |index|
+          index.as :symbol
+        end
+
+        after_create :create_transfer_request
+      end
+
+      def create_transfer_request
+        ContentDepositorChangeEventJob.perform_later(id, on_behalf_of) if on_behalf_of.present?
+      end
+
+      def request_transfer_to(target)
+        raise ArgumentError, "Must provide a target" unless target
+        deposit_user = ::User.find_by_user_key(depositor)
+        ProxyDepositRequest.create!(generic_work_id: id, receiving_user: target, sending_user: deposit_user)
+      end
+    end
+  end
+end

--- a/curation_concerns-models/app/models/concerns/curation_concerns/file_set_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/file_set_behavior.rb
@@ -14,6 +14,7 @@ module CurationConcerns
     include CurationConcerns::FileSet::Indexing
     include CurationConcerns::FileSet::BelongsToWorks
     include CurationConcerns::FileSet::Querying
+    include CurationConcerns::FileSet::ProxyDeposit
     include CurationConcerns::HumanReadableType
     include CurationConcerns::RequiredMetadata
     include CurationConcerns::Naming


### PR DESCRIPTION
When the user uploads a file as a proxy user, the 'on_behalf_of' method is missing. Related to Sufia issue: https://github.com/projecthydra/sufia/issues/1551
