### PR TITLE
Copy the configuration from the root path

### DIFF
--- a/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
+++ b/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
@@ -4,7 +4,7 @@ module CurationConcerns::CurationConcernController
   include Blacklight::AccessControls::Catalog
 
   included do
-    copy_blacklight_config_from(CatalogController)
+    copy_blacklight_config_from(::CatalogController)
     include CurationConcerns::ThemedLayoutController
     with_themed_layout '1_column'
     helper CurationConcerns::AbilityHelper


### PR DESCRIPTION
Otherwise it sometimes attempts to resolve it to
CurationConcerns::CatalogController, which is not where the config is
located.