### PR TITLE
Remove GenericWork from Solr index

### DIFF
--- a/curation_concerns-models/app/models/concerns/curation_concerns/with_file_sets.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/with_file_sets.rb
@@ -18,8 +18,13 @@ module CurationConcerns
       # Destroy the list source first.  This prevents each file_set from attemping to
       # remove itself individually from the work. If hundreds of files are attached,
       # this would take too long.
+
+      # Get list of member file_sets from Solr
+      fs = file_sets
       list_source.destroy
-      file_sets.each(&:destroy)
+      # Remove Work from Solr after it was removed from Fedora
+      ActiveFedora::SolrService.delete(id)
+      fs.each(&:destroy)
     end
 
     def copy_visibility_to_files


### PR DESCRIPTION
Removing work from solr index before FileSets are destroyed so in_objects lookup  does not explode.  This fixed one of two errors that arise from including hydra-works 0.7.0