### PR TITLE
remove ordered_member_ids from work form

### DIFF
--- a/app/forms/curation_concerns/forms/work_form.rb
+++ b/app/forms/curation_concerns/forms/work_form.rb
@@ -14,7 +14,7 @@ module CurationConcerns
                     :representative_id, :thumbnail_id, :files,
                     :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo,
                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,
-                    :visibility, :ordered_member_ids]
+                    :visibility]
 
       # @param [ActiveFedora::Base,#member_ids] model
       # @param [Ability] current_ability


### PR DESCRIPTION
fixes the error: "GenericWork does not have an attribute `ordered_member_ids’"

This might not be the right solution. The error is generated in Sufia, when a new work is created. Here are the steps to generate the error:
1. Create a new work.
2. Hit Save
The error says: ActiveFedora::UnknownAttributeError Exception: GenericWork does not have an attribute `ordered_member_ids’
In the process of debugging, I noticed that when I create a form using CC, the attributes in base actor are:
{"title"=>[], "creator"=>[], "contributor"=>[], "description"=>[], "rights"=>[], "publisher"=>[], "subject"=>[], "language"=>[], "visibility"=>"restricted”}
But when base actor is called from Sufia, the attributes are:
(byebug) attributes
{"title"=>[], "creator"=>[], "contributor"=>[], "description"=>[], "tag"=>[], "publisher"=>[], "date_created"=>[], "subject"=>[], "language"=>[], "identifier"=>[], "based_near"=>[], "related_url"=>[], "visibility"=>"restricted", "ordered_member_ids"=>[], "resource_type"=>[]}

And that is where the error is generated..
If I remove the :ordered_member_ids from work_form.rb, I can save the new work form  in CC and Sufia

Any thoughts? @mjgiarlo , @grosscol,  @tpendragon , @awead , @jcoyne 
