### PR TITLE
Add a way to run tests without rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,22 +9,29 @@ require 'active_fedora/rake_support'
 
 Dir.glob('tasks/*.rake').each { |r| import r }
 
-desc 'Run style checker'
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.requires << 'rubocop-rspec'
-  task.fail_on_error = true
+namespace :curation_concerns do
+  desc 'Run style checker'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.requires << 'rubocop-rspec'
+    task.fail_on_error = true
+  end
+
+  RSpec::Core::RakeTask.new(:rspec)
+
+  desc 'Run test suite'
+  task :spec do
+    with_test_server do
+      Rake::Task['curation_concerns:rspec'].invoke
+    end
+  end
 end
 
 desc 'Run test suite and style checker'
-task spec: :rubocop do
-  RSpec::Core::RakeTask.new(:spec)
-end
+task spec: ['curation_concerns:rubocop', 'curation_concerns:spec']
 
 desc 'Spin up Solr & Fedora and run the test suite'
 task ci: ['engine_cart:generate'] do
-  with_test_server do
-    Rake::Task['spec'].invoke
-  end
+  Rake::Task['spec'].invoke
 end
 
 task clean: 'engine_cart:clean'


### PR DESCRIPTION
This allows you to use byebug or save_and_open_page without rubocop
complaining.

    rake curation_concerns:spec