### PR TITLE
require date_uploaded and date_modified fields

### DIFF
--- a/curation_concerns-models/app/models/concerns/curation_concerns/basic_metadata.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/basic_metadata.rb
@@ -38,20 +38,6 @@ module CurationConcerns
         index.as :stored_searchable
       end
 
-      # We reserve date_uploaded for the original creation date of the record.
-      # For example, when migrating data from a fedora3 repo to fedora4,
-      # fedora's system created date will reflect the date when the record
-      # was created in fedora4, but the date_uploaded will preserve the
-      # original creation date from the old repository.
-      property :date_uploaded, predicate: ::RDF::Vocab::DC.dateSubmitted, multiple: false do |index|
-        index.type :date
-        index.as :stored_sortable
-      end
-
-      property :date_modified, predicate: ::RDF::Vocab::DC.modified, multiple: false do |index|
-        index.type :date
-        index.as :stored_sortable
-      end
       property :subject, predicate: ::RDF::Vocab::DC.subject do |index|
         index.as :stored_searchable, :facetable
       end

--- a/curation_concerns-models/app/models/concerns/curation_concerns/required_metadata.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/required_metadata.rb
@@ -6,8 +6,24 @@ module CurationConcerns
       property :depositor, predicate: ::RDF::URI.new('http://id.loc.gov/vocabulary/relators/dpt'), multiple: false do |index|
         index.as :symbol, :stored_searchable
       end
+
       property :title, predicate: ::RDF::Vocab::DC.title do |index|
         index.as :stored_searchable, :facetable
+      end
+
+      # We reserve date_uploaded for the original creation date of the record.
+      # For example, when migrating data from a fedora3 repo to fedora4,
+      # fedora's system created date will reflect the date when the record
+      # was created in fedora4, but the date_uploaded will preserve the
+      # original creation date from the old repository.
+      property :date_uploaded, predicate: ::RDF::Vocab::DC.dateSubmitted, multiple: false do |index|
+        index.type :date
+        index.as :stored_sortable
+      end
+
+      property :date_modified, predicate: ::RDF::Vocab::DC.modified, multiple: false do |index|
+        index.type :date
+        index.as :stored_sortable
       end
     end
   end


### PR DESCRIPTION
Because they are used in the actor.

Fixes #628