### PR TITLE
Allow create_content to take a relationship arg

### DIFF
--- a/curation_concerns-models/app/actors/curation_concerns/file_set_actor.rb
+++ b/curation_concerns-models/app/actors/curation_concerns/file_set_actor.rb
@@ -41,7 +41,8 @@ module CurationConcerns
     # TODO: create a job to monitor this directory and prune old files that
     # have made it to the repo
     # @param [File, ActionDigest::HTTP::UploadedFile, Tempfile] file the file uploaded by the user.
-    def create_content(file)
+    # @param [String] relation ('original_file')
+    def create_content(file, relation = 'original_file')
       # Assign label and title of File Set is necessary.
       file_set.label ||= file.respond_to?(:original_filename) ? file.original_filename : ::File.basename(file)
       file_set.title = [file_set.label] if file_set.title.blank?
@@ -51,7 +52,7 @@ module CurationConcerns
 
       working_file = copy_file_to_working_directory(file, file_set.id)
       mime_type = file.respond_to?(:content_type) ? file.content_type : nil
-      IngestFileJob.perform_later(file_set.id, working_file, mime_type, user.user_key)
+      IngestFileJob.perform_later(file_set.id, working_file, mime_type, user.user_key, relation)
       make_derivative(file_set.id, working_file)
       true
     end

--- a/curation_concerns-models/app/jobs/ingest_file_job.rb
+++ b/curation_concerns-models/app/jobs/ingest_file_job.rb
@@ -1,7 +1,12 @@
 class IngestFileJob < ActiveJob::Base
   queue_as :ingest
 
-  def perform(file_set_id, filename, mime_type, user_key)
+  # @param [String] file_set_id
+  # @param [String] filename
+  # @param [String,NilClass] mime_type
+  # @param [String] user_key
+  # @param [String] relation ('original_file')
+  def perform(file_set_id, filename, mime_type, user_key, relation = 'original_file')
     file_set = FileSet.find(file_set_id)
 
     file = File.open(filename, "rb")
@@ -14,14 +19,14 @@ class IngestFileJob < ActiveJob::Base
     end
 
     # Tell AddFileToFileSet service to skip versioning because versions will be minted by VersionCommitter (called by save_characterize_and_record_committer) when necessary
-    Hydra::Works::AddFileToFileSet.call(file_set, file, :original_file, versioning: false)
+    Hydra::Works::AddFileToFileSet.call(file_set, file, relation.to_sym, versioning: false)
 
     # Persist changes to the file_set
     file_set.save!
 
     # Do post file ingest actions
     user = User.find_by_user_key(user_key)
-    CurationConcerns::VersioningService.create(file_set.original_file, user)
+    CurationConcerns::VersioningService.create(file_set.send(relation.to_sym), user)
     CurationConcerns.config.callback.run(:after_create_content, file_set, user)
   end
 end

--- a/spec/actors/curation_concerns/file_set_actor_spec.rb
+++ b/spec/actors/curation_concerns/file_set_actor_spec.rb
@@ -22,7 +22,7 @@ describe CurationConcerns::FileSetActor do
 
     before do
       expect(CharacterizeJob).to receive(:perform_later)
-      expect(IngestFileJob).to receive(:perform_later).with(file_set.id, /world\.png$/, 'image/png', user.user_key)
+      expect(IngestFileJob).to receive(:perform_later).with(file_set.id, /world\.png$/, 'image/png', user.user_key, 'original_file')
       allow(actor).to receive(:acquire_lock_for).and_yield
       actor.create_metadata(work)
       actor.create_content(uploaded_file)
@@ -68,8 +68,16 @@ describe CurationConcerns::FileSetActor do
   describe '#create_content' do
     it 'calls ingest file job' do
       expect(CharacterizeJob).to receive(:perform_later)
-      expect(IngestFileJob).to receive(:perform_later).with(file_set.id, /world\.png$/, 'image/png', user.user_key)
+      expect(IngestFileJob).to receive(:perform_later).with(file_set.id, /world\.png$/, 'image/png', user.user_key, 'original_file')
       actor.create_content(uploaded_file)
+    end
+
+    context 'when an alternative relationship is specified' do
+      it 'calls ingest file job' do
+        expect(CharacterizeJob).to receive(:perform_later)
+        expect(IngestFileJob).to receive(:perform_later).with(file_set.id, /world\.png$/, 'image/png', user.user_key, 'remastered')
+        actor.create_content(uploaded_file, 'remastered')
+      end
     end
 
     context 'using ::File' do


### PR DESCRIPTION
This enables use of the FileSetActor for files besides the original
file.  In our case we're using it for a preservation quality derivative
of the original.