### PR TITLE
Exepmt the install generator from coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,7 @@ if ENV['COVERAGE'] || $in_travis
   SimpleCov.start('rails') do
     add_filter '/spec'
     add_filter '/lib/generators/curation_concerns/templates'
+    add_filter '/lib/generators/curation_concerns/install_generator.rb'
     add_filter '/.internal_test_app'
   end
   SimpleCov.command_name('spec')


### PR DESCRIPTION
It is run prior to spec_helper being run, and we are testing it by using
the sample application that it has generated.