### PR TITLE
Bump hydra-collections to ~> 8.0

### DIFF
--- a/app/forms/curation_concerns/forms/collection_edit_form.rb
+++ b/app/forms/curation_concerns/forms/collection_edit_form.rb
@@ -18,6 +18,35 @@ module CurationConcerns
         model_class.validators_on(key).any? { |v| v.is_a? ActiveModel::Validations::PresenceValidator }
       end
 
+      # The form only supports a single value for title, so use the first
+      # @return [String] the first title
+      def title
+        model.title.first
+      end
+
+      # The form only supports a single value for description, so use the first
+      # @return [String] the first description
+      def description
+        model.description.first
+      end
+
+      # @param [Symbol] key the property to test for cardinality
+      # @return [FalseClass,TrueClass] whether the value on the form is singular or multipl
+      def self.multiple?(key)
+        return false if [:title, :description].include? key
+        super
+      end
+
+      # @param [ActiveSupport::Parameters]
+      # @return [Hash] a hash suitable for populating Collection attributes.
+      def self.model_attributes(_)
+        attrs = super
+        # cast title and description back to multivalued
+        attrs[:title] = Array(attrs[:title]) if attrs[:title]
+        attrs[:description] = Array(attrs[:description]) if attrs[:description]
+        attrs
+      end
+
       # @return [Hash] All generic files in the collection, file.to_s is the key, file.id is the value
       def select_files
         Hash[all_files]

--- a/app/helpers/curation_concerns/collections_helper.rb
+++ b/app/helpers/curation_concerns/collections_helper.rb
@@ -1,8 +1,4 @@
 module CurationConcerns::CollectionsHelper
-  def has_collection_search_parameters?
-    params[:cq].present?
-  end
-
   def collection_modal_id(collectible)
     "#{collectible.to_param.tr(':', '-')}-modal"
   end

--- a/curation_concerns-models/app/models/concerns/curation_concerns/collection_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/collection_behavior.rb
@@ -10,7 +10,7 @@ module CurationConcerns
     include CurationConcerns::Permissions
 
     included do
-      validates :title, presence: true
+      validates_with HasOneTitleValidator
     end
 
     def to_s

--- a/curation_concerns-models/app/validators/has_one_title_validator.rb
+++ b/curation_concerns-models/app/validators/has_one_title_validator.rb
@@ -1,0 +1,8 @@
+# validates that the title has at least one title
+class HasOneTitleValidator < ActiveModel::Validator
+  def validate(record)
+    if record.title.reject(&:empty?).empty?
+      record.errors[:title] << "You must provide a title"
+    end
+  end
+end

--- a/curation_concerns-models/curation_concerns-models.gemspec
+++ b/curation_concerns-models/curation_concerns-models.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'active_attr'
-  spec.add_dependency 'hydra-collections', '~> 7.0'
+  spec.add_dependency 'hydra-collections', '~> 8.0'
   spec.add_dependency 'hydra-head', '~> 9.3'
   spec.add_dependency 'hydra-works', '~> 0.7'
   spec.add_dependency 'active_fedora-noid', '~> 1.0'

--- a/spec/controllers/curation_concerns/collections_controller_spec.rb
+++ b/spec/controllers/curation_concerns/collections_controller_spec.rb
@@ -6,14 +6,24 @@ describe CollectionsController do
     allow_any_instance_of(User).to receive(:groups).and_return([])
   end
 
-  let(:user) { FactoryGirl.create(:user) }
-  let(:asset1) { FactoryGirl.build(:generic_work, title: ['First of the Assets'], user: user) }
-  let(:asset2) { FactoryGirl.build(:generic_work, title: ['Second of the Assets'], user: user, depositor: user.user_key) }
-  let(:asset3) { FactoryGirl.build(:generic_work, title: ['Third of the Assets']) }
-  let!(:asset4) { FactoryGirl.create(:generic_work, title: ['Fourth of the Assets'], user: user) }
-  let(:bogus_depositor_asset) { FactoryGirl.create(:generic_work, title: ['Bogus Asset'], depositor: 'abc') }
-  let(:collection_attrs) { FactoryGirl.attributes_for(:collection, title: 'My First Collection ', description: "The Description\r\n\r\nand more") }
-  let(:collection) { FactoryGirl.create(:collection, title: 'Collection Title', user: user) }
+  let(:user) { create(:user) }
+  let(:asset1) { build(:generic_work, title: ['First of the Assets'], user: user) }
+  let(:asset2) { build(:generic_work,
+                       title: ['Second of the Assets'],
+                       user: user,
+                       depositor: user.user_key) }
+  let(:asset3) { build(:generic_work, title: ['Third of the Assets']) }
+  let!(:asset4) { create(:generic_work,
+                         title: ['Fourth of the Assets'],
+                         user: user) }
+  let(:bogus_depositor_asset) { create(:generic_work,
+                                       title: ['Bogus Asset'],
+                                       depositor: 'abc') }
+  let(:collection_attrs) do
+    { title: 'My First Collection', description: "The Description\r\n\r\nand more" }
+  end
+
+  let(:collection) { create(:collection, title: ['Collection Title'], user: user) }
 
   describe '#new' do
     before do
@@ -42,7 +52,7 @@ describe CollectionsController do
       expect do
         post :create, collection: collection_attrs.merge(creator: [''])
       end.to change { Collection.count }.by(1)
-      expect(assigns[:collection].title).to eq('My First Collection ')
+      expect(assigns[:collection].title).to eq ['My First Collection']
       expect(assigns[:collection].creator).to eq([])
     end
 
@@ -138,7 +148,7 @@ describe CollectionsController do
 
       it 'removes blank strings from params before updating Collection metadata' do
         put :update, id: collection, collection: collection_attrs.merge(creator: [''])
-        expect(assigns[:collection].title).to eq('My First Collection ')
+        expect(assigns[:collection].title).to eq ['My First Collection']
         expect(assigns[:collection].creator).to eq([])
       end
     end
@@ -160,7 +170,7 @@ describe CollectionsController do
         get :show, id: collection
         expect(response).to be_successful
         expect(assigns[:presenter]).to be_kind_of CurationConcerns::CollectionPresenter
-        expect(assigns[:presenter].title).to eq collection.title
+        expect(assigns[:presenter].title).to eq 'Collection Title'
         expect(assigns[:member_docs].map(&:id)).to match_array [asset1, asset2, asset3].map(&:id)
       end
 
@@ -169,7 +179,7 @@ describe CollectionsController do
           get :show, id: collection, q: 'no matches'
           expect(response).to be_successful
           expect(assigns[:presenter]).to be_kind_of CurationConcerns::CollectionPresenter
-          expect(assigns[:presenter].title).to eq collection.title
+          expect(assigns[:presenter].title).to eq 'Collection Title'
         end
       end
     end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
       user { FactoryGirl.create(:user) }
     end
 
-    title 'Test collection title'
+    title ['Test collection title']
 
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 feature 'Catalog index page' do
   let!(:work) { create(:public_generic_work, title: ['My Work']) }
-  let!(:coll) { create(:collection, :public, title: 'My Collection') }
+  let!(:coll) { create(:collection, :public, title: ['My Collection']) }
 
   scenario 'Browse the catalog using filter tabs' do
     visit search_catalog_path

--- a/spec/forms/collection_edit_form_spec.rb
+++ b/spec/forms/collection_edit_form_spec.rb
@@ -65,9 +65,7 @@ describe CurationConcerns::Forms::CollectionEditForm do
       let(:title) { work.file_sets.first.title.first }
       let(:file_id) { work.file_sets.first.id }
       let(:collection_with_file) do
-        Collection.create!(title: 'foo', members: [work]) do |c|
-          c.apply_depositor_metadata('jcoyne')
-        end
+        create(:collection, members: [work])
       end
 
       it 'returns a hash of with file title as key and file id as value' do

--- a/spec/helpers/curation_concerns/collections_helper_spec.rb
+++ b/spec/helpers/curation_concerns/collections_helper_spec.rb
@@ -35,14 +35,14 @@ describe CurationConcerns::CollectionsHelper do
     before do
       allow(helper).to receive(:current_user).and_return(user)
     end
-    let(:user) { FactoryGirl.create(:user) }
-    let!(:collection1) { FactoryGirl.create(:collection, user: user, title: 'One') }
-    let!(:collection2) { FactoryGirl.create(:collection, user: user, title: 'Two') }
-    let!(:collection3) { FactoryGirl.create(:collection, user: user, title: 'Three') }
+    let(:user) { create(:user) }
+    let!(:collection1) { create(:collection, user: user, title: ['One']) }
+    let!(:collection2) { create(:collection, user: user, title: ['Two']) }
+    let!(:collection3) { create(:collection, user: user, title: ['Three']) }
     subject { helper.collection_options_for_select(collection2) }
 
     it 'excludes the passed in collection' do
-      expect(subject).to eq "<option value=\"#{collection1.id}\">#{collection1.title}</option>\n<option value=\"#{collection3.id}\">#{collection3.title}</option>"
+      expect(subject).to eq "<option value=\"#{collection1.id}\">One</option>\n<option value=\"#{collection3.id}\">Three</option>"
     end
   end
 end

--- a/spec/presenters/curation_concerns/collection_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/collection_presenter_spec.rb
@@ -1,8 +1,13 @@
 require 'spec_helper'
 
 describe CurationConcerns::CollectionPresenter do
-  let(:collection) { Collection.new(id: 'adc12v', description: 'a nice collection', title: 'A clever title') }
-  let(:work) { FactoryGirl.build(:work, title: ['unimaginitive title']) }
+  let(:collection) do
+    build(:collection,
+          id: 'adc12v',
+          description: ['a nice collection'],
+          title: ['A clever title'])
+  end
+  let(:work) { build(:work, title: ['unimaginitive title']) }
   let(:solr_document) { SolrDocument.new(collection.to_solr) }
   let(:ability) { double }
   let(:presenter) { described_class.new(solr_document, ability) }

--- a/spec/views/catalog/index.html.erb_spec.rb
+++ b/spec/views/catalog/index.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'catalog/index.html.erb' do
-  let(:collection) { stub_model(Collection, title: 'collection1', id: 'abc123') }
+  let(:collection) { stub_model(Collection, title: ['collection1'], id: 'abc123') }
   let(:doc) { SolrDocument.new(collection.to_solr) }
   let(:search_state) { double('SearchState', to_h: {}) }
   let(:blacklight_configuration_context) do
@@ -44,7 +44,7 @@ describe 'catalog/index.html.erb' do
     it 'appears on page without error' do
       render
       page = Capybara::Node::Simple.new(rendered)
-      expect(page).to have_link(collection.title)
+      expect(page).to have_link 'collection1'
       expect(page).to have_content 'List of items deposited'
     end
   end
@@ -55,7 +55,7 @@ describe 'catalog/index.html.erb' do
     it 'appears on page without error' do
       render
       page = Capybara::Node::Simple.new(rendered)
-      expect(page).to have_link(collection.title)
+      expect(page).to have_link 'collection1'
       expect(page).to have_content 'List of items deposited'
     end
   end


### PR DESCRIPTION
This causes the collection metadata to look the same as work metadata (multiple titles and descriptions)