### PR TITLE
Allow passing options to the resource routes

### DIFF
--- a/lib/curation_concerns/rails/routes.rb
+++ b/lib/curation_concerns/rails/routes.rb
@@ -1,24 +1,10 @@
 module ActionDispatch::Routing
   class Mapper
-    # @yield If a block is passed it is yielded for each curation_concern
-    # @example
-    #   curation_concerns_basic_routes do
-    #     concerns :exportable
-    #   end
-    def curation_concerns_basic_routes(&block)
+    def curation_concerns_basic_routes
       resources :downloads, only: :show
       resources :upload_sets, only: [:edit, :update]
 
       namespace :curation_concerns, path: :concern do
-        concerns_to_route.each do |curation_concern_name|
-          namespaced_resources curation_concern_name, except: [:index], &block
-          namespaced_resources curation_concern_name, only: [] do
-            member do
-              get :file_manager
-            end
-          end
-        end
-
         resources :permissions, only: [] do
           member do
             get :confirm
@@ -30,6 +16,35 @@ module ActionDispatch::Routing
           member do
             get :versions
             put :rollback
+          end
+        end
+      end
+    end
+
+    # @yield If a block is passed it is yielded for each curation_concern
+    # @example
+    #   curation_concerns_resource_routes do
+    #     concerns :exportable
+    #   end
+    def curation_concerns_resource_routes(&block)
+      concerns_to_route.each do |curation_concern_name|
+        curation_concerns_named_resouce_route curation_concern_name, &block
+      end
+    end
+
+    # @param [String] curation_concern_name
+    # @param [Hash] options extra options to pass to the routes
+    # @yield If a block is passed it is yielded for each curation_concern
+    # @example
+    #   curation_concerns_named_resouce_route constraints: { id: /[A-Z][A-Z][0-9]+/ } do
+    #     concerns :exportable
+    #   end
+    def curation_concerns_named_resouce_route(curation_concern_name, options = {}, &block)
+      namespace :curation_concerns, path: :concern do
+        namespaced_resources curation_concern_name, options.merge(except: [:index]), &block
+        namespaced_resources curation_concern_name, only: [] do
+          member do
+            get :file_manager
           end
         end
       end

--- a/lib/generators/curation_concerns/install_generator.rb
+++ b/lib/generators/curation_concerns/install_generator.rb
@@ -63,6 +63,7 @@ module CurationConcerns
         "  root 'welcome#index'\n"\
         "  curation_concerns_collections\n"\
         "  curation_concerns_basic_routes\n"\
+        "  curation_concerns_resource_routes\n"\
         "  curation_concerns_embargo_management\n"\
       end
     end


### PR DESCRIPTION
This allow us to pass constraint options to the resource route methods
via the newly created `curation_concerns_named_resouce_route` method.

When upgrading, one will have to add `curation_concerns_resource_routes`
into `config/routes.rb`, as that's no longer part of
`curation_concerns_basic_routes`