### PR TITLE
Add to collection button shouldn't be a primary button

### DIFF
--- a/app/views/curation_concerns/base/_show_actions.html.erb
+++ b/app/views/curation_concerns/base/_show_actions.html.erb
@@ -8,7 +8,7 @@
     <% end %>
     <% if collector %>
       <%= render 'collections/add_to_collection_modal', collectible: @presenter %>
-      <%= link_to_select_collection @presenter, class: 'btn btn-primary' %>
+      <%= link_to_select_collection @presenter, class: 'btn btn-default' %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
There's no reason this button should be favored over the others:

<img width="746" alt="screen shot 2016-03-03 at 10 20 01 am" src="https://cloud.githubusercontent.com/assets/92044/13500766/8aea6100-e129-11e5-9bc5-9404f93761e2.png">
