### PR TITLE
Return zero when members is null

### DIFF
--- a/app/presenters/curation_concerns/collection_presenter.rb
+++ b/app/presenters/curation_concerns/collection_presenter.rb
@@ -25,7 +25,7 @@ module CurationConcerns
     end
 
     def total_items
-      @solr_document['member_ids_ssim'].length
+      @solr_document.fetch('member_ids_ssim', []).length
     end
   end
 end

--- a/spec/presenters/curation_concerns/collection_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/collection_presenter_spec.rb
@@ -39,5 +39,9 @@ describe CurationConcerns::CollectionPresenter do
       before { collection.members << work }
       it { is_expected.to eq 1 }
     end
+    context "null members" do
+      let(:presenter) { described_class.new({}, nil) }
+      it { is_expected.to eq 0 }
+    end
   end
 end


### PR DESCRIPTION
refs projecthydra/sufia#1620

`member_ids_ssim` is sometimes not present in the solr document, yielding a NilClass error when calling `CurationConcerns::CollectionsPresenter.total_items`. This returns zero if the solr field is not present.

@projecthydra/sufia-code-reviewers

