### PR TITLE
Don't parse date_created as a Date, fixes #657

### DIFF
--- a/app/presenters/curation_concerns/collection_presenter.rb
+++ b/app/presenters/curation_concerns/collection_presenter.rb
@@ -18,7 +18,7 @@ module CurationConcerns
 
     # Metadata Methods
     delegate :title, :description, :creator, :contributor, :subject, :publisher, :language,
-             :embargo_release_date, :lease_expiration_date, :rights, to: :solr_document
+             :embargo_release_date, :lease_expiration_date, :rights, :date_created, to: :solr_document
 
     def size
       number_to_human_size(@solr_document['bytes_is'])

--- a/curation_concerns-models/app/models/concerns/curation_concerns/solr_document_behavior.rb
+++ b/curation_concerns-models/app/models/concerns/curation_concerns/solr_document_behavior.rb
@@ -44,8 +44,9 @@ module CurationConcerns
       fetch(Solrizer.solr_name('hasRelatedMediaFragment', :symbol), []).first
     end
 
+    # Date created is indexed as a string. This allows users to enter values like: 'Circa 1840-1844'
     def date_created
-      date_field('date_created')
+      fetch(Solrizer.solr_name("date_created"), []).first
     end
 
     def date_modified

--- a/spec/presenters/curation_concerns/collection_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/collection_presenter_spec.rb
@@ -5,7 +5,8 @@ describe CurationConcerns::CollectionPresenter do
     build(:collection,
           id: 'adc12v',
           description: ['a nice collection'],
-          title: ['A clever title'])
+          title: ['A clever title'],
+          date_created: ['some date'])
   end
   let(:work) { build(:work, title: ['unimaginitive title']) }
   let(:solr_document) { SolrDocument.new(collection.to_solr) }
@@ -43,5 +44,10 @@ describe CurationConcerns::CollectionPresenter do
       let(:presenter) { described_class.new({}, nil) }
       it { is_expected.to eq 0 }
     end
+  end
+
+  describe "#date_created" do
+    subject { presenter.date_created }
+    it { is_expected.to eq 'some date' }
   end
 end

--- a/spec/presenters/curation_concerns/work_show_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/work_show_presenter_spec.rb
@@ -8,7 +8,7 @@ describe CurationConcerns::WorkShowPresenter do
     { "title_tesim" => ["foo bar"],
       "human_readable_type_tesim" => ["Generic Work"],
       "has_model_ssim" => ["GenericWork"],
-      "date_created_dtsi" => date_index,
+      "date_created_tesim" => ['an unformatted date'],
       "date_modified_dtsi" => date_index,
       "date_uploaded_dtsi" => date_index }
   end
@@ -31,7 +31,12 @@ describe CurationConcerns::WorkShowPresenter do
     it { is_expected.to be_kind_of ActiveModel::Name }
   end
 
-  [:date_created, :date_modified, :date_uploaded].each do |date_field|
+  describe "#date_created" do
+    subject { presenter.date_created }
+    it { is_expected.to eq('an unformatted date') }
+  end
+
+  [:date_modified, :date_uploaded].each do |date_field|
     describe "##{date_field}" do
       subject { presenter.send date_field }
       it { is_expected.to eq date_value.to_formatted_s(:standard) }


### PR DESCRIPTION
Fixes #657 

`date_created` is indexed as a string, so we should display it like one.

Changes proposed in this pull request:
* display date_created as string instead of trying to parse it like a Date

@projecthydra/sufia-code-reviewers