### PR TITLE
Don't require rubocop-rspec from .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,3 @@
-require: rubocop-rspec
-
 AllCops:
   DisplayCopNames: true
   Include:


### PR DESCRIPTION
Rubocop 0.38.0 breaks the require of rubocop-rspec. This removes this require.
```
Running RuboCop...

rake aborted!

LoadError: cannot load such file -- /home/travis/build/projecthydra-labs/curation_concerns/rubocop-rspec

/home/travis/build/projecthydra-labs/curation_concerns/vendor/bundle/ruby/2.2.0/gems/rubocop-0.38.0/lib/rubocop/config_loader.rb:40:in `require'
```
Waiting on bbatsov/rubocop#2936 to be merged