### PR TITLE
Extract work_types method on SearchBuilder

### DIFF
--- a/app/search_builders/curation_concerns/filter_by_type.rb
+++ b/app/search_builders/curation_concerns/filter_by_type.rb
@@ -14,9 +14,16 @@ module CurationConcerns
 
     private
 
+      # Override this method if you want to limit some of the registered
+      # types from appearing in search results
+      # @returns [Array<Class>] the list of work types to include in searches
+      def work_types
+        CurationConcerns.config.curation_concerns
+      end
+
       def work_clauses
         return [] if blacklight_params.key?(:f) && Array(blacklight_params[:f][:generic_type_sim]).include?('Collection')
-        CurationConcerns.config.registered_curation_concern_types.map(&:constantize).map do |klass|
+        work_types.map do |klass|
           ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: klass.to_class_uri)
         end
       end

--- a/spec/search_builders/curation_concerns/search_builder_spec.rb
+++ b/spec/search_builders/curation_concerns/search_builder_spec.rb
@@ -32,10 +32,23 @@ describe CurationConcerns::SearchBuilder do
   end
 
   describe '#filter_models' do
-    before { subject.filter_models(solr_params) }
+    context "with default work types" do
+      before { subject.filter_models(solr_params) }
 
-    it 'limits query to collection and generic work' do
-      expect(solr_params[:fq].first).to match(/{!raw f=has_model_ssim}GenericWork.*OR.*{!raw f=has_model_ssim}Collection/)
+      it 'limits query to collection and generic work' do
+        expect(solr_params[:fq].first).to match(/{!raw f=has_model_ssim}GenericWork.*OR.*{!raw f=has_model_ssim}Collection/)
+      end
+    end
+
+    context 'when work_types is overridden' do
+      before do
+        allow(subject).to receive(:work_types).and_return([FileSet])
+        subject.filter_models(solr_params)
+      end
+
+      it "doesn't have GenericWork" do
+        expect(solr_params[:fq].first).not_to match(/{!raw f=has_model_ssim}GenericWork/)
+      end
     end
   end
 end


### PR DESCRIPTION
This enables an implementer to customize the work types that should be
returned by a search

@projecthydra/sufia-code-reviewers
