### PR TITLE
Convert Bytes to a stored long

### DIFF
--- a/app/presenters/curation_concerns/collection_presenter.rb
+++ b/app/presenters/curation_concerns/collection_presenter.rb
@@ -21,7 +21,7 @@ module CurationConcerns
              :embargo_release_date, :lease_expiration_date, :rights, :date_created, to: :solr_document
 
     def size
-      number_to_human_size(@solr_document['bytes_is'])
+      number_to_human_size(@solr_document['bytes_lts'])
     end
 
     def total_items

--- a/curation_concerns-models/app/indexers/curation_concerns/collection_indexer.rb
+++ b/curation_concerns-models/app/indexers/curation_concerns/collection_indexer.rb
@@ -1,14 +1,14 @@
 module CurationConcerns
   class CollectionIndexer < Hydra::PCDM::CollectionIndexer
     include IndexesThumbnails
-    STORED_INTEGER = Solrizer::Descriptor.new(:integer, :stored)
+    STORED_LONG = Solrizer::Descriptor.new(:long, :stored)
 
     def generate_solr_document
       super.tap do |solr_doc|
         # Makes Collections show under the "Collections" tab
         Solrizer.set_field(solr_doc, 'generic_type', 'Collection', :facetable)
         # Index the size of the collection in bytes
-        solr_doc[Solrizer.solr_name(:bytes, STORED_INTEGER)] = object.bytes
+        solr_doc[Solrizer.solr_name(:bytes, STORED_LONG)] = object.bytes
         solr_doc['thumbnail_path_ss'] = thumbnail_path
       end
     end

--- a/curation_concerns-models/curation_concerns-models.gemspec
+++ b/curation_concerns-models/curation_concerns-models.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'resque-pool', '~> 0.3'
   spec.add_dependency 'qa', '~> 0.5'
   spec.add_dependency 'redlock', '~> 0.1.2'
+  spec.add_dependency 'solrizer', '~> 3.4'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'

--- a/spec/indexers/collection_indexer_spec.rb
+++ b/spec/indexers/collection_indexer_spec.rb
@@ -13,7 +13,7 @@ describe CurationConcerns::CollectionIndexer do
 
     it "has required fields" do
       expect(subject.fetch('generic_type_sim')).to eq ["Collection"]
-      expect(subject.fetch('bytes_is')).to eq(1000)
+      expect(subject.fetch('bytes_lts')).to eq(1000)
       expect(subject.fetch('thumbnail_path_ss')).to eq "/downloads/1234?file=thumbnail"
     end
   end


### PR DESCRIPTION
Solr has a 32-bit max value for integers, so collections with large files were quickly going over it and failing to index. By using a long instead it at least makes the number significantly larger before there's a problem.

@projecthydra/sufia-code-reviewers

