### PR TITLE
The title attribute is required.

### DIFF
--- a/app/forms/curation_concerns/forms/work_form.rb
+++ b/app/forms/curation_concerns/forms/work_form.rb
@@ -16,6 +16,8 @@ module CurationConcerns
                     :visibility_during_lease, :lease_expiration_date, :visibility_after_lease,
                     :visibility, :ordered_member_ids]
 
+      self.required_fields = [:title]
+
       # @param [ActiveFedora::Base,#member_ids] model
       # @param [Ability] current_ability
       def initialize(model, current_ability)

--- a/spec/forms/work_form_spec.rb
+++ b/spec/forms/work_form_spec.rb
@@ -116,4 +116,9 @@ describe CurationConcerns::Forms::WorkForm do
     subject { form.lease_expiration_date }
     it { is_expected.to eq curation_concern.lease_expiration_date }
   end
+
+  describe ".required_fields" do
+    subject { described_class.required_fields }
+    it { is_expected.to eq [:title] }
+  end
 end


### PR DESCRIPTION
Fixes #678

This causes the title on the form to be styled as a required attribute so the user knows they have to enter it.

@projecthydra/sufia-code-reviewers

