### PR TITLE
Use `feature` instead of `describe` for feature specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+require: rubocop-rspec
 AllCops:
   DisplayCopNames: true
   Include:
@@ -177,7 +178,6 @@ RSpec/DescribeClass:
     - 'spec/javascripts/jasmine_spec.rb'
     - 'spec/tasks/rake_spec.rb'
     - 'spec/abilities/**/*'
-    - 'spec/features/**/*'
     - 'spec/views/**/*'
     - 'spec/routing/**/*'
     - 'spec/inputs/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 gem 'curation_concerns-models', path: './curation_concerns-models'
 
 group :development, :test do
-  gem 'rubocop', require: false
+  gem 'rubocop', '~> 0.37.0', require: false
   gem 'rubocop-rspec', '~> 1.3.1', require: false
   gem 'simplecov', '~> 0.9', require: false
   gem 'coveralls', require: false

--- a/spec/features/add_file_spec.rb
+++ b/spec/features/add_file_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Add an attached file' do
+feature 'Add an attached file' do
   let(:user) { create(:user) }
   let!(:work) { create(:work, user: user) }
 

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 include CurationConcerns::SearchPathsHelper
 
-describe 'collection' do
+feature 'collection' do
   let(:title1) { 'Test Collection 1' }
   let(:description1) { 'Description for collection 1 we are testing.' }
   let(:title2) { 'Test Collection 2' }

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'redlock'
 
-describe 'Creating a new Work' do
+feature 'Creating a new Work' do
   let(:user) { FactoryGirl.create(:user) }
 
   let(:redlock_client_stub) { # stub out redis connection

--- a/spec/features/embargo_spec.rb
+++ b/spec/features/embargo_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'embargo' do
+feature 'embargo' do
   let(:user) { FactoryGirl.create(:user) }
   before do
     sign_in user

--- a/spec/features/lease_spec.rb
+++ b/spec/features/lease_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'leases' do
+feature 'leases' do
   let(:user) { FactoryGirl.create(:user) }
   before do
     sign_in user

--- a/spec/features/update_file_spec.rb
+++ b/spec/features/update_file_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Editing attached files' do
+feature 'Editing attached files' do
   let(:user) { create(:user) }
   let!(:parent) { create(:work_with_one_file, user: user) }
   let!(:file_set) { parent.file_sets.first }

--- a/spec/features/work_generator_spec.rb
+++ b/spec/features/work_generator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rails/generators'
 require 'redlock'
 
-describe 'Creating a new Work' do
+feature 'Creating a new Work' do
   let(:user) { FactoryGirl.create(:user) }
 
   let(:redlock_client_stub) { # stub out redis connection


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

This allows us to remove an exception from .rubocop.yml
I've also reenabled the require of rubocop-rspec and pinned rubocop to
0.37 so we can still use it.