### PR TITLE
WorkShowPresenter#file_presenters only returns FileSets

### DIFF
--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -24,18 +24,41 @@ module CurationConcerns
              :creator, :contributor, :subject, :publisher, :language, :embargo_release_date,
              :lease_expiration_date, :rights, to: :solr_document
 
+    # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
+    def file_set_presenters
+      @file_set_presenters ||= member_presenters(ordered_ids & file_set_ids)
+    end
+
+    # @deprecated
+    # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
     def file_presenters
-      @file_sets ||= PresenterFactory.build_presenters(ordered_ids,
-                                                       file_presenter_class,
-                                                       current_ability)
+      Deprecation.warn WorkShowPresenter, "file_presenters is deprecated and will be removed in CurationConcerns 1.0. Use file_set_presenters or member_presenters instead."
+      member_presenters
+    end
+
+    # @return [Array<FileSetPresenter>] presenters for the ordered_members (not filtered by class)
+    def member_presenters(ids = ordered_ids)
+      PresenterFactory.build_presenters(ids,
+                                        file_presenter_class,
+                                        current_ability)
     end
 
     private
 
       # TODO: Extract this to ActiveFedora::Aggregations::ListSource
       def ordered_ids
-        ActiveFedora::SolrService.query("proxy_in_ssi:#{id}", fl: "ordered_targets_ssim")
+        ActiveFedora::SolrService.query("proxy_in_ssi:#{id}",
+                                        fl: "ordered_targets_ssim")
                                  .flat_map { |x| x.fetch("ordered_targets_ssim", []) }
+      end
+
+      # These are the file sets that belong to this work, but not necessarily
+      # in order.
+      def file_set_ids
+        ActiveFedora::SolrService.query("{!field f=has_model_ssim}FileSet",
+                                        fl: "id",
+                                        fq: "{!join from=ordered_targets_ssim to=id}id:\"#{id}/list_source\"")
+                                 .flat_map { |x| x.fetch("id", []) }
       end
 
       # Override this method if you want to use an alternate presenter class for the files

--- a/app/views/curation_concerns/base/_related_files.html.erb
+++ b/app/views/curation_concerns/base/_related_files.html.erb
@@ -1,4 +1,4 @@
-<% if presenter.file_presenters.present? %>
+<% if presenter.file_set_presenters.present? %>
 <div class="panel panel-default related_files">
   <div class="panel-heading">
     <h2>Files</h2>
@@ -14,7 +14,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render partial: 'member', collection: presenter.file_presenters %>
+      <%= render partial: 'member', collection: presenter.file_set_presenters %>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

This prevents members that are not FileSets from drawing in the section
of the page that is the list of attached files. For example if you have
a Book that has members that are Sections and FileSets we want to
exclude the Sections from displaying in the table of files.

Ref https://github.com/curationexperts/heliotrope/issues/84