### PR TITLE
Fixed issue where re-ordering attached files wasn't working. Story curationexperts/heliotrope#83

### DIFF
--- a/app/assets/javascripts/curation_concerns/file_manager/save_manager.es6
+++ b/app/assets/javascripts/curation_concerns/file_manager/save_manager.es6
@@ -5,7 +5,7 @@ class SaveManager {
   }
 
   override_save_button() {
-    jQuery(() => {
+    Blacklight.onLoad(() => {
       this.save_button.click(this.clicked_save)
     })
   }

--- a/spec/javascripts/save_manager_spec.coffee
+++ b/spec/javascripts/save_manager_spec.coffee
@@ -43,6 +43,7 @@ describe "FileManager Save Button", ->
         expect($("button.disabled").length).toEqual(1)
   describe "#persist", ->
     it "is called by clicking the save button", ->
+      Blacklight.activate();
       spyOn(save_manager, "persist").and.callThrough()
       save_manager.push_changed(handler)
 


### PR DESCRIPTION
refs curationexperts/heliotrope#83

When I tried using the FileManager page to re-order files attached to a generic work, the "Save" button wasn't working.  But if I reloaded the page, then everything worked properly as expected.

This seems to be a problem with turbolinks, so I changed the javascript to use Blacklight.onLoad, which should gracefully handle the turbolinks case.

Ping @tpendragon for review.  Trey:  Could you take a look at the change I made to the spec and let me know if there is a better way to do it?  That spec failed when I changed the javascript.  At the beginning of the spec, I just manually called Blacklight.activate(), which is what would normally get called by Blacklight.onLoad:
https://github.com/projectblacklight/blacklight/blob/b11cf399a1416b995322032031f5543a5387cc8c/app/assets/javascripts/blacklight/core.js#L19