### PR TITLE
WIP: Adding the browse_everything gem

### DIFF
--- a/app/assets/javascripts/curation_concerns/application.js
+++ b/app/assets/javascripts/curation_concerns/application.js
@@ -13,3 +13,9 @@
 //= require jquery-ui/sortable
 //
 //= require curation_concerns/curation_concerns
+
+//
+// For Browse-everything until https://github.com/projecthydra-labs/browse-everything/issues/85 is resolved:
+//= require jquery.treetable
+//= require browse_everything/behavior
+//

--- a/app/assets/stylesheets/curation_concerns/_curation_concerns.scss
+++ b/app/assets/stylesheets/curation_concerns/_curation_concerns.scss
@@ -10,3 +10,4 @@
 @import "curation_concerns/typography";
 @import 'hydra-editor/multi_value_fields';
 @import 'curation_concerns/fileupload';
+@import "browse_everything";

--- a/app/controllers/concerns/curation_concerns/browse_everything.rb
+++ b/app/controllers/concerns/curation_concerns/browse_everything.rb
@@ -1,0 +1,33 @@
+module CurationConcerns::BrowseEverything
+  include ActiveSupport::Concern
+
+  def create
+    if params[:selected_files].present?
+      create_from_browse_everything(params)
+    else
+      super
+    end
+  end
+
+  protected
+
+    def create_from_browse_everything(params)
+      parent = ActiveFedora::Base.find(params.fetch(:parent_id))
+      params[:selected_files].each_pair do |_index, file_info|
+        next if file_info.blank? || file_info["url"].blank?
+        create_file_from_url(file_info["url"], file_info["file_name"], parent)
+      end
+      redirect_to main_app.curation_concerns_generic_work_path(parent_id)
+    end
+
+    # Generic utility for creating FileSet from a URL
+    # Used in to import files using URLs from a file picker like browse_everything
+    def create_file_from_url(url, file_name, parent)
+      ::FileSet.new(import_url: url, label: file_name) do |fs|
+        actor = CurationConcerns::FileSetActor.new(fs, current_user)
+        actor.create_metadata(parent)
+        fs.save!
+        ImportUrlJob.perform_later(fs.id)
+      end
+    end
+end

--- a/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
@@ -10,6 +10,7 @@ module CurationConcerns
       load_and_authorize_resource class: ::FileSet, except: :show
       helper_method :curation_concern
       include CurationConcerns::ParentContainer
+      include CurationConcerns::BrowseEverything
       copy_blacklight_config_from(::CatalogController)
 
       class_attribute :show_presenter, :form_class
@@ -148,8 +149,17 @@ module CurationConcerns
       end
 
       def file_set_params
-        params.require(:file_set).permit(
-          :visibility_during_embargo, :embargo_release_date, :visibility_after_embargo, :visibility_during_lease, :lease_expiration_date, :visibility_after_lease, :visibility, title: [])
+        params.permit(
+          :file_set,
+          :selected_files,
+          :visibility_during_embargo,
+          :embargo_release_date,
+          :visibility_after_embargo,
+          :visibility_during_lease,
+          :lease_expiration_date,
+          :visibility_after_lease,
+          :visibility,
+          title: [])
       end
 
       def version_list

--- a/app/views/curation_concerns/base/_multiple_upload.html.erb
+++ b/app/views/curation_concerns/base/_multiple_upload.html.erb
@@ -1,3 +1,27 @@
-<%= render 'curation_concerns/file_sets/upload/alerts', presenter: @presenter %>
-<%= render 'curation_concerns/file_sets/upload/form', presenter: @presenter %>
-<%= render 'curation_concerns/file_sets/upload/script_templates', presenter: @presenter %>
+<ul class="nav nav-tabs" role="tablist" title="Data Source Selectors" id="upload_tabs">
+  <li class="active" id="computer_tab" title="<%= t('curation_concern.upload.my_computer.sr_tab_label')+' '+ t('curation_concern.upload.my_computer.tab_label') %>"><a role="tab" href="#local" data-toggle="tab"><i class="glyphicon glyphicon-folder-open" aria-hidden="true"></i> <%= t('curation_concern.upload.my_computer.tab_label')%></a></li>
+  <% if CurationConcerns.config.browse_everything %>
+      <li id="browse_everything_tab" title="<%= t('curation_concern.upload.browse_everything.sr_tab_label')+' '+ t('curation_concern.upload.browse_everything.tab_label') %>" aria-activedescendant="browse_everything_link"><a role="tab" href="#browse_everything" data-toggle="tab" id="browse_everything_link" ><i class="glyphicon glyphicon-cloud-download" aria-hidden="true"></i> <%= t('curation_concern.upload.browse_everything.tab_label')%></a></li>
+  <% end %>
+</ul>
+
+
+<div class="tab-content">
+  <div class="tab-pane active" id="local" aria-labelledby="computer_tab" role="tabpanel">
+    <span class="sr-only"><%= t("curation_concern.upload.my_computer.sr_instructions") %></span>
+    <%= render 'curation_concerns/file_sets/upload/alerts', presenter: @presenter %>
+    <%= render 'curation_concerns/file_sets/upload/form', presenter: @presenter %>
+    <%= render 'curation_concerns/file_sets/upload/script_templates', presenter: @presenter %>
+  </div>
+
+  <% if CurationConcerns.config.browse_everything %>
+      <div class="tab-pane" id="browse_everything"  aria-labelledby="browse_everything_tab" role="tabpanel">
+        <%= render 'curation_concerns/file_sets/upload/browse_everything', presenter: @presenter %>
+      </div>
+  <% end %>
+
+</div>
+
+
+
+

--- a/app/views/curation_concerns/base/_show_actions.html.erb
+++ b/app/views/curation_concerns/base/_show_actions.html.erb
@@ -2,7 +2,6 @@
   <div class="form-actions">
     <% if editor %>
       <%= link_to "Edit This #{@presenter.human_readable_type}", edit_polymorphic_path([main_app, @presenter]), class: 'btn btn-default' %>
-      <%= link_to "Attach a File", main_app.new_curation_concerns_file_set_path(@presenter), class: 'btn btn-default' %>
       <%= link_to t("file_manager.link_text"), polymorphic_path([main_app, :file_manager, @presenter]), class: 'btn btn-default' %>
       <%= link_to "Delete This #{@presenter.human_readable_type}", [main_app, @presenter], class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{@presenter.human_readable_type}?" }, method: :delete %>
     <% end %>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -7,10 +7,7 @@
 <% editor    = can?(:edit,    @presenter.id) %>
 
 <%= render 'representative_media', presenter: @presenter %>
-<%= render "attributes", presenter: @presenter %>
+<%= render 'attributes', presenter: @presenter %>
 <%= render 'related_files', presenter: @presenter %>
-<% if editor %>
-  <%= render 'multiple_upload', presenter: @presenter %>
-<% end %>
-
-<%= render "show_actions", collector: collector, editor: editor%>
+<%= render 'multiple_upload', presenter: @presenter if editor %>
+<%= render 'show_actions', collector: collector, editor: editor%>

--- a/app/views/curation_concerns/file_sets/upload/_browse_everything.html.erb
+++ b/app/views/curation_concerns/file_sets/upload/_browse_everything.html.erb
@@ -1,0 +1,24 @@
+<div class="alert alert-success">
+
+</div>
+<div class="well">
+  <%= form_tag(main_app.curation_concerns_file_sets_path(parent_id: @presenter.id), html: { multipart: true, id: 'browse_everything_form'}, method: 'post') do %>
+      <%= hidden_field_tag(:batch_id, @batch_id) %>
+      <%= button_tag(t('curation_concerns.upload.browse_everything.browse_files_button'), type: 'button', class: 'btn btn-lg btn-success', id: "browse-btn",
+        'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,
+        'data-target' => '#browse_everything_form' ) %>
+      <%= button_tag("Submit selected files", type: 'submit', class: 'activate-submit btn btn-lg btn-primary', id: "submit-btn") %>
+  <% end %>
+
+  <p id="status">0 items selected</p>
+</div>
+<script>
+  // Update the count in #status element when user selects files.
+  $(document).ready(function() {
+    $('#browse-btn').browseEverything()
+      .done(function(data) {
+        $('#status').html(data.length.toString() + " <%= t('curation_concerns.upload.browse_everything.files_selected')%>")
+        $('#submit-btn').html("Submit "+data.length.toString() + " selected files")
+      })
+  });
+</script>

--- a/config/locales/curation_concerns.en.yml
+++ b/config/locales/curation_concerns.en.yml
@@ -20,6 +20,11 @@ en:
           placeholder: "Type keywords in here"
     bread_crumb:
       works_list: "the works browser"
+    browse_everything:
+      sr_tab_label: "Access Files from"
+      tab_label: "Cloud Providers"
+      browse_files_button: "Browse cloud files"
+      files_selected: "files selected"
     messages:
       success:
         single: "has been saved."

--- a/curation_concerns-models/lib/curation_concerns/configuration.rb
+++ b/curation_concerns-models/lib/curation_concerns/configuration.rb
@@ -75,6 +75,11 @@ module CurationConcerns
       @max_days_between_audits ||= 7
     end
 
+    attr_writer :browse_everything
+    def browse_everything
+      @browse_everything ||= true
+    end
+
     attr_writer :enable_noids
     def enable_noids
       return @enable_noids unless @enable_noids.nil?

--- a/curation_concerns-models/lib/curation_concerns/models/engine.rb
+++ b/curation_concerns-models/lib/curation_concerns/models/engine.rb
@@ -1,10 +1,20 @@
 module CurationConcerns
   module Models
+    def self.config(&block)
+      @@config ||= Engine::Configuration.new
+
+      yield @@config if block
+
+      @@config
+    end
+
     class Engine < ::Rails::Engine
       config.autoload_paths += %W(
         #{config.root}/app/actors/concerns
         #{config.root}/lib/curation_concerns
       )
+
+      config.browse_everything = nil
 
       initializer 'requires' do
         require 'active_fedora/noid'

--- a/curation_concerns-models/lib/generators/curation_concerns/models/templates/config/curation_concerns.rb
+++ b/curation_concerns-models/lib/generators/curation_concerns/models/templates/config/curation_concerns.rb
@@ -56,6 +56,17 @@ CurationConcerns.configure do |config|
   # Leaving it blank will set the start date to when ever the file was uploaded by
   # NOTE: if you have always sent analytics to GA for downloads and page views leave this commented out
   # config.analytic_start_date = DateTime.new(2014,9,10)
+
+  # If browse-everything has been configured, load the configs.  Otherwise, set to nil.
+  begin
+    if defined? BrowseEverything
+      config.browse_everything = BrowseEverything.config
+    else
+      Rails.logger.warn "BrowseEverything is not installed"
+    end
+  rescue Errno::ENOENT
+    config.browse_everything = nil
+  end
 end
 
 Date::DATE_FORMATS[:standard] = '%m/%d/%Y'

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails_autolink'
   spec.add_dependency 'sprockets-es6'
   spec.add_dependency 'kaminari_route_prefix', '~> 0.0.1'
+  spec.add_dependency 'browse-everything', '~> 0.4'
 
   spec.add_development_dependency 'solr_wrapper', '~> 0.4'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'

--- a/lib/curation_concerns.rb
+++ b/lib/curation_concerns.rb
@@ -3,6 +3,8 @@ require 'curation_concerns/engine'
 require 'curation_concerns/configuration'
 require 'blacklight_advanced_search'
 require 'kaminari_route_prefix'
+require 'browse_everything'
+require 'font-awesome-rails'
 
 module CurationConcerns
 end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -20,4 +20,8 @@ class TestAppGenerator < Rails::Generators::Base
     remove_file 'spec/controllers/curation_concerns/generic_works_controller_spec.rb'
     remove_file 'spec/actors/curation_concerns/generic_work_actor_spec.rb'
   end
+
+  def browse_everything_config
+    generate "browse_everything:config"
+  end
 end


### PR DESCRIPTION
This is the current state of adding the BrowseEverything gem into CurationConcerns. It's only working about halfway, but I have questions before it can be finished.

Here's how it presently looks:
<img width="1177" alt="cc-be" src="https://cloud.githubusercontent.com/assets/312085/13880252/d5f40286-ecf1-11e5-8889-b45fe8e6d8ee.png">

The upload UI has been ported over directly from Sufia, which means it includes the default upload from computer behavior. Is this what you want? Otherwise, we can remove that and have only the BE upload process?

This work was started at the dev meeting in San Diego last month. This is an effort to document how far we got. I may not have time to finish this, given Sufia 7 sprint requirements, so I'm marking where things are.

@projecthydra/sufia-code-reviewers