### PR TITLE
Remove body styling

### DIFF
--- a/app/assets/stylesheets/curation_concerns/_positioning.scss
+++ b/app/assets/stylesheets/curation_concerns/_positioning.scss
@@ -1,7 +1,3 @@
-body {
-  padding:0 1em 1em;
-}
-
 #brand-bar-wrapper, #title-bar-wrapper {
   margin-left:-1em;
   margin-right:-1em;


### PR DESCRIPTION
I'd argue curation_concerns shouldn't concern itself with styling the `body` element; instead, it should defer to the application.