### PR TITLE
Override remove_constraint_url

### DIFF
--- a/app/helpers/curation_concerns/render_constraints_helper.rb
+++ b/app/helpers/curation_concerns/render_constraints_helper.rb
@@ -1,20 +1,32 @@
 module CurationConcerns
   module RenderConstraintsHelper
-    # Overridden to remove the 'search_field' tag from the localized params when the query is cleared.
-    # This is because unlike Blacklight, there is no way to change the search_field in the curation_concerns UI
-    ##
-    # Render the query constraints
-    #
-    # @param [Hash] query parameters
-    # @return [String]
+    # TODO: we can remove this override when we can depend on https://github.com/projectblacklight/blacklight/pull/1398
     def render_constraints_query(localized_params = params)
       # So simple don't need a view template, we can just do it here.
-      return ''.html_safe if localized_params[:q].blank?
+      return "".html_safe if localized_params[:q].blank?
 
       render_constraint_element(constraint_query_label(localized_params),
                                 localized_params[:q],
-                                classes: ['query'],
-                                remove: url_for(localized_params.except(:search_field).merge(q: nil, action: 'index')))
+                                classes: ["query"],
+                                remove: remove_constraint_url(localized_params))
+    end
+
+    # This overrides Blacklight to remove the 'search_field' tag from the
+    # localized params when the query is cleared. This is because unlike
+    # Blacklight, there is no control to change the search_field in the
+    # curation_concerns UI
+    def remove_constraint_url(localized_params)
+      scope = localized_params.delete(:route_set) || self
+      options = localized_params.merge(q: nil, action: 'index')
+                                .except(*fields_to_exclude_from_constraint_element)
+      options.permit!
+      scope.url_for(options)
+    end
+
+    # @return [Array<Symbol>] a list of fields to remove on the render_constraint_element
+    # You can override this if you have different fields to remove
+    def fields_to_exclude_from_constraint_element
+      [:search_field]
     end
 
     ##

--- a/spec/helpers/render_constraints_helper_spec.rb
+++ b/spec/helpers/render_constraints_helper_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe CurationConcernsHelper do
+  let(:search_params) do
+    ActionController::Parameters.new(q: 'Simon',
+                                     search_field: 'publisher',
+                                     controller: 'catalog')
+  end
   describe 'render_constraints_query' do
     before do
       # Stub methods from Blacklight::SearchFields
@@ -8,12 +13,29 @@ describe CurationConcernsHelper do
       allow(helper).to receive(:label_for_search_field).and_return('Foo')
     end
 
-    let(:search_params) { { q: 'Simon', search_field: 'publisher', controller: 'catalog' } }
     subject { helper.render_constraints_query(search_params) }
 
     it 'removes search_field' do
       node = Capybara::Node::Simple.new(subject)
       expect(node).to have_link 'Remove constraint Foo: Simon', href: search_catalog_path
     end
+
+    it 'calls remove_constraint_url' do
+      expect(helper).to receive(:remove_constraint_url).and_return('/hello')
+      expect(subject).to include 'href="/hello"'
+    end
+  end
+
+  describe 'remove_constraint_url' do
+    subject { helper.remove_constraint_url(search_params) }
+    it 'calls fields_to_exclude_from_constraint_element' do
+      expect(helper).to receive(:fields_to_exclude_from_constraint_element).and_return([])
+      expect(subject).to eq "/catalog?search_field=publisher"
+    end
+  end
+
+  describe 'fields_to_exclude_from_constraint_element' do
+    subject { helper.fields_to_exclude_from_constraint_element }
+    it { is_expected.to eq [:search_field] }
   end
 end


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

This prepares CurationConcerns to be aligned with Blacklight.
https://github.com/projectblacklight/blacklight/pull/1398

This also gives applications like sufia a smaller override footprint. In
this case we'll only override
`fields_to_exclude_from_constraint_element`