### PR TITLE
Work around for duplicate predicate issue

### DIFF
--- a/app/models/concerns/curation_concerns/file_set_behavior.rb
+++ b/app/models/concerns/curation_concerns/file_set_behavior.rb
@@ -1,6 +1,12 @@
 module CurationConcerns
   module FileSetBehavior
     extend ActiveSupport::Concern
+    # BasicMetadata needs to be included before Characterization since
+    # both of them declare properties with the same predicate (dc:creator
+    # and dc:language.) Loading BasicMetadata first allows Characterization
+    # to detect the duplicate (via the AlreadyThereStrategy) and prevents
+    # the warning.
+    include CurationConcerns::BasicMetadata
     include Hydra::Works::FileSetBehavior
     include Hydra::Works::VirusCheck
     include Hydra::Works::Characterization
@@ -9,7 +15,6 @@ module CurationConcerns
     include CurationConcerns::Noid
     include CurationConcerns::FileSet::Derivatives
     include CurationConcerns::Permissions
-    include CurationConcerns::BasicMetadata
     include CurationConcerns::FileSet::FullTextIndexing
     include CurationConcerns::FileSet::Indexing
     include CurationConcerns::FileSet::BelongsToWorks

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -105,7 +105,7 @@ describe FileSet do
       expect(subject).to respond_to(:well_formed)
       expect(subject).to respond_to(:page_count)
       expect(subject).to respond_to(:file_title)
-      expect(subject).to respond_to(:file_author)
+      expect(subject).to respond_to(:creator)
     end
 
     it 'redefines to_param to make redis keys more recognizable' do


### PR DESCRIPTION
This is to address issue https://github.com/projecthydra/sufia/issues/1693 reported in Sufia but that also happens in CurationConcerns.

The culprit is that both BasicMetadata (in CurationConcerns) and Characterization (in HydraWorks) define properties that map to the same predicate. By forcing BasicMedatata to be included before Characterization the issue does not happen (because Characterization detects the conflict via the AlreadyThereStrategy.)

To see the problem load the FileSet class via the Rails console and notice the warning:
```
$ bundle exec rails console
Loading development environment (Rails 4.2.6)
irb(main):001:0> FileSet
Same predicate (http://purl.org/dc/elements/1.1/creator) used for properties creator and creator
Same predicate (http://purl.org/dc/elements/1.1/language) used for properties language and language
=> FileSet
irb(main):002:0> exit
```

On a codebase with the fix proposed in this PR the warning is not issued.
```
$ bundle exec rails console
Loading development environment (Rails 4.2.6)
irb(main):001:0> FileSet
=> FileSet
irb(main):002:0> exit
```

See also this PR https://github.com/projecthydra-labs/hydra-works/pull/288