### PR TITLE
Make admin group configurable

### DIFF
--- a/app/models/concerns/curation_concerns/ability.rb
+++ b/app/models/concerns/curation_concerns/ability.rb
@@ -25,6 +25,8 @@ module CurationConcerns
       can [:create, :discover, :show, :read, :edit, :update, :destroy], :all
     end
 
+    # Override this method in your ability model if you use a different group
+    # or other logic to designate an administrator.
     def admin?
       user_groups.include? 'admin'
     end

--- a/app/search_builders/curation_concerns/search_filters.rb
+++ b/app/search_builders/curation_concerns/search_filters.rb
@@ -6,7 +6,7 @@ module CurationConcerns::SearchFilters
   # Override Hydra::AccessControlsEnforcement (or Hydra::PolicyAwareAccessControlsEnforcement)
   # Allows admin users to see everything (don't apply any gated_discovery_filters for those users)
   def gated_discovery_filters(permission_types = discovery_permissions, ability = current_ability)
-    return [] if ability.current_user.groups.include? 'admin'
+    return [] if ability.admin?
     super
   end
 

--- a/spec/search_builders/curation_concerns/search_builder_spec.rb
+++ b/spec/search_builders/curation_concerns/search_builder_spec.rb
@@ -12,8 +12,7 @@ describe CurationConcerns::SearchBuilder do
   describe '#gated_discovery_filters' do
     before do
       allow(subject).to receive(:current_ability).and_return(ability)
-      allow(ability).to receive(:current_user).and_return(user)
-      allow(user).to receive(:groups).and_return(['admin'])
+      allow(ability).to receive(:admin?).and_return(true)
     end
 
     it 'does not filter results for admin users' do


### PR DESCRIPTION
Use `Ability#admin?` so you can override to provide your own logic.

@projecthydra/sufia-code-reviewers