### PR TITLE
Excise unhelpful styling from search form partial

### DIFF
--- a/app/views/collections/_search_form.html.erb
+++ b/app/views/collections/_search_form.html.erb
@@ -1,6 +1,4 @@
-<div class="col-md-3 pull-right">
   <%= form_for @presenter, method: :get, class: "well form-search" do |f| %>
-
       <label class="sr-only">Search Collection <%= @presenter.title %></label>
       <div class="input-group">
         <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: "Search Collection", size: '30', type: "search", id: "collection_search" %>
@@ -11,4 +9,3 @@
       <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
       <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:cq, :sort, :qt, :page)) %>
   <% end %>
-</div>


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Consumers should be able to style/contain this form.  The idea that
3-bootstrap columns or always pull-right works for all consumers is
counter-productive.

Reference https://github.com/projecthydra/sufia/issues/1875