### PR TITLE
Ignore page parameter on the collection query

### DIFF
--- a/app/controllers/concerns/curation_concerns/collections_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/collections_controller_behavior.rb
@@ -160,7 +160,7 @@ module CurationConcerns
       end
 
       def collection_search_builder
-        collection_search_builder_class.new(self).with(params.except(:q)).tap do |builder|
+        collection_search_builder_class.new(self).with(params.except(:q, :page)).tap do |builder|
           builder.current_ability = current_ability
         end
       end

--- a/spec/controllers/curation_concerns/collections_controller_spec.rb
+++ b/spec/controllers/curation_concerns/collections_controller_spec.rb
@@ -181,6 +181,14 @@ describe CollectionsController do
           expect(assigns[:presenter].title).to eq 'Collection Title'
         end
       end
+      context 'when the page parameter is passed' do
+        it 'loads the collection (paying no attention to the page param)' do
+          get :show, id: collection, page: '2'
+          expect(response).to be_successful
+          expect(assigns[:presenter]).to be_kind_of CurationConcerns::CollectionPresenter
+          expect(assigns[:presenter].title).to eq 'Collection Title'
+        end
+      end
     end
 
     context 'not signed in' do


### PR DESCRIPTION
Fixes issue https://github.com/projecthydra/sufia/issues/1835 (reported in Sufia) 

When rendering the Collection show page the Solr query that fetches the collection information was picking up the `page` parameter that was intended for the members of the collection. 

When the user wanted to see "page 2 of collection members" the query to fetch the collection information was returning no results because of the "page 2" parameter. 

This PR fixes that issue. We honor the "page X" parameter only to fetch the members of the collection.

@projecthydra/sufia-code-reviewers

