### PR TITLE
Set timestamp columns to null: false

### DIFF
--- a/lib/generators/curation_concerns/templates/migrations/create_checksum_audit_logs.rb
+++ b/lib/generators/curation_concerns/templates/migrations/create_checksum_audit_logs.rb
@@ -7,7 +7,7 @@ class CreateChecksumAuditLogs < ActiveRecord::Migration
       t.integer :pass
       t.string :expected_result
       t.string :actual_result
-      t.timestamps
+      t.timestamps null: false
     end
     add_index :checksum_audit_logs, [:file_set_id, :file_id], name: 'by_file_set_id_and_file_id', order: { created_at: 'DESC' }
   end

--- a/lib/generators/curation_concerns/templates/migrations/create_single_use_links.rb
+++ b/lib/generators/curation_concerns/templates/migrations/create_single_use_links.rb
@@ -6,7 +6,7 @@ class CreateSingleUseLinks < ActiveRecord::Migration
       t.string :itemId
       t.datetime :expires
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/lib/generators/curation_concerns/templates/migrations/create_version_committers.rb
+++ b/lib/generators/curation_concerns/templates/migrations/create_version_committers.rb
@@ -5,7 +5,7 @@ class CreateVersionCommitters < ActiveRecord::Migration
       t.string :datastream_id
       t.string :version_id
       t.string :committer_login
-      t.timestamps
+      t.timestamps null: false
     end
   end
 


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

This avoids a deprecation warning by setting this property explicitly