### PR TITLE
Fix brand bar margin issue

### DIFF
--- a/app/assets/stylesheets/curation_concerns/_positioning.scss
+++ b/app/assets/stylesheets/curation_concerns/_positioning.scss
@@ -1,5 +1,4 @@
 #brand-bar {
-  margin-bottom :0;
   z-index: $zindex-navbar + 1;
 }
 


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

Fixes style issue with brand bar and title bar. Setting the brand bar bottom margin to zero causes an ugly overlap.

![screenshot 2016-04-26 17 57 59](https://cloud.githubusercontent.com/assets/784196/14835946/c52db336-0bda-11e6-82f6-2fd2163c3319.png)

