### PR TITLE
Display an error if the FileSet can't be updated

### DIFF
--- a/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
@@ -92,6 +92,7 @@ module CurationConcerns
         respond_to do |wants|
           wants.html do
             initialize_edit_form
+            flash[:error] = "There was a problem processing your request."
             render 'edit', status: :unprocessable_entity
           end
           wants.json { render_json_response(response_type: :unprocessable_entity, options: { errors: @file_set.errors }) }

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -135,6 +135,7 @@ describe CurationConcerns::FileSetsController do
           expect(response).to render_template('edit')
           expect(assigns[:groups]).to be_kind_of Array
           expect(assigns[:file_set]).to eq file_set
+          expect(flash[:error]).to eq "There was a problem processing your request."
         end
 
         context 'updating visibility' do


### PR DESCRIPTION
Previously it was just silently failing.

@projecthydra/sufia-code-reviewers

Ref https://github.com/projecthydra/sufia/issues/1933