### PR TITLE
Run callbacks for curation concern lifecycle events

### DIFF
--- a/app/actors/curation_concerns/base_actor.rb
+++ b/app/actors/curation_concerns/base_actor.rb
@@ -11,16 +11,21 @@ module CurationConcerns
       @cloud_resources = attributes.delete(:cloud_resources.to_s)
       apply_creation_data_to_curation_concern
       apply_save_data_to_curation_concern(attributes)
-      next_actor.create(attributes) && save
+      next_actor.create(attributes) && save && run_callbacks(:after_create_concern)
     end
 
     def update(attributes)
       apply_update_data_to_curation_concern
       apply_save_data_to_curation_concern(attributes)
-      next_actor.update(attributes) && save
+      next_actor.update(attributes) && save && run_callbacks(:after_update_metadata)
     end
 
     protected
+
+      def run_callbacks(hook)
+        CurationConcerns.config.callback.run(hook, curation_concern, user)
+        true
+      end
 
       def apply_creation_data_to_curation_concern
         apply_depositor_metadata

--- a/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
+++ b/app/controllers/concerns/curation_concerns/curation_concern_controller.rb
@@ -93,6 +93,7 @@ module CurationConcerns::CurationConcernController
   def destroy
     title = curation_concern.to_s
     curation_concern.destroy
+    CurationConcerns.config.callback.run(:after_destroy, curation_concern.id, current_user)
     after_destroy_response(title)
   end
 

--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -24,6 +24,6 @@ class IngestFileJob < ActiveJob::Base
 
     # Do post file ingest actions
     CurationConcerns::VersioningService.create(file_set.send(relation.to_sym), user)
-    CurationConcerns.config.callback.run(:after_create_content, file_set, user)
+    CurationConcerns.config.callback.run(:after_create_fileset, file_set, user)
   end
 end

--- a/lib/curation_concerns/configuration.rb
+++ b/lib/curation_concerns/configuration.rb
@@ -132,11 +132,12 @@ module CurationConcerns
       @lock_retry_delay ||= 200 # milliseconds
     end
 
-    callback.enable :after_create_content, :after_update_content,
-                    :after_revert_content, :after_update_metadata,
-                    :after_import_local_file_success,
+    callback.enable :after_create_concern, :after_create_fileset,
+                    :after_update_content, :after_revert_content,
+                    :after_update_metadata, :after_import_local_file_success,
                     :after_import_local_file_failure, :after_audit_failure,
-                    :after_destroy, :after_import_url_success, :after_import_url_failure
+                    :after_destroy, :after_import_url_success,
+                    :after_import_url_failure
 
     # Registers the given curation concern model in the configuration
     # @param [Array<Symbol>,Symbol] curation_concern_types

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -215,6 +215,12 @@ describe CurationConcerns::GenericWorksController do
       expect(GenericWork).not_to exist(work_to_be_deleted.id)
     end
 
+    it "invokes the after_destroy callback" do
+      expect(CurationConcerns.config.callback).to receive(:run)
+        .with(:after_destroy, work_to_be_deleted.id, user)
+      delete :destroy, id: work_to_be_deleted
+    end
+
     context 'someone elses public work' do
       let(:work_to_be_deleted) { create(:private_generic_work) }
       it 'shows unauthorized message' do

--- a/spec/jobs/ingest_file_job_spec.rb
+++ b/spec/jobs/ingest_file_job_spec.rb
@@ -68,10 +68,10 @@ describe IngestFileJob do
     end
   end
 
-  describe "the after_create_content callback" do
+  describe "the after_create_fileset callback" do
     subject { CurationConcerns.config.callback }
     it 'runs with file_set and user arguments' do
-      expect(subject).to receive(:run).with(:after_create_content, file_set, user)
+      expect(subject).to receive(:run).with(:after_create_fileset, file_set, user)
       described_class.perform_now(file_set, filename, 'image/png', user)
     end
   end


### PR DESCRIPTION
Split `:after_create_content` callback into `:after_create_concern` and `:after_create_fileset` since we're already special-casing FileSets; this allows us to differentiate between attaching FileSets and creating other concerns.

Fixes #752 