### PR TITLE
Upgrade to hydra-editor 2.0

### DIFF
--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "breadcrumbs_on_rails", "~> 2.3"
   spec.add_dependency "jquery-ui-rails"
   spec.add_dependency "simple_form", '~> 3.1'
-  spec.add_dependency 'hydra-editor', '~> 1.1'
+  spec.add_dependency 'hydra-editor', '~> 2.0'
   spec.add_dependency 'blacklight_advanced_search', '~> 6.0'
   spec.add_dependency 'rails_autolink'
   spec.add_dependency 'sprockets-es6'

--- a/lib/generators/curation_concerns/install_generator.rb
+++ b/lib/generators/curation_concerns/install_generator.rb
@@ -17,6 +17,7 @@ module CurationConcerns
    7. Adds CurationConcerns::SolrDocumentBehavior to app/models/solr_document.rb
    8. Adds config/authorities/rights.yml to the application
    9. Adds config/authorities/resource_types.yml to the application
+   10. Runs simple_form:install --bootstrap
          '
 
     def run_required_generators
@@ -98,6 +99,10 @@ module CurationConcerns
 
     def resource_types_config
       copy_file "config/authorities/resource_types.yml", "config/authorities/resource_types.yml"
+    end
+
+    def simple_form_bootstrap
+      generate 'simple_form:install --bootstrap'
     end
   end
 end


### PR DESCRIPTION
This requires implementations that are upgrading to run:
```
rails generate simple_form:install --bootstrap
```

This changes the text of the "Add" button to be "More" in compliance with the recommendations of the UI WG
@projecthydra/sufia-code-reviewers

