### PR TITLE
Fix bug with callback execution paths

### DIFF
--- a/app/actors/curation_concerns/file_set_actor.rb
+++ b/app/actors/curation_concerns/file_set_actor.rb
@@ -69,10 +69,7 @@ module CurationConcerns
       stack = ActorStack.new(file_set,
                              user,
                              [InterpretVisibilityActor, BaseActor])
-      if result = stack.update(attributes)
-        CurationConcerns.config.callback.run(:after_update_metadata, file_set, user)
-      end
-      result
+      stack.update(attributes)
     end
 
     def destroy
@@ -123,6 +120,7 @@ module CurationConcerns
           # Save the work so the association between the work and the file_set is persisted (head_id)
           work.save
         end
+        CurationConcerns.config.callback.run(:after_create_fileset, file_set, user)
       end
 
       def assign_visibility?(file_set_params = {})

--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -24,6 +24,5 @@ class IngestFileJob < ActiveJob::Base
 
     # Do post file ingest actions
     CurationConcerns::VersioningService.create(file_set.send(relation.to_sym), user)
-    CurationConcerns.config.callback.run(:after_create_fileset, file_set, user)
   end
 end

--- a/spec/actors/curation_concerns/file_set_actor_spec.rb
+++ b/spec/actors/curation_concerns/file_set_actor_spec.rb
@@ -35,7 +35,7 @@ describe CurationConcerns::FileSetActor do
     end
 
     context 'when a work is provided' do
-      let(:work) { FactoryGirl.create(:generic_work) }
+      let(:work) { create(:generic_work) }
 
       it 'adds the generic file to the parent work' do
         expect(subject.generic_works).to eq [work]
@@ -203,6 +203,7 @@ describe CurationConcerns::FileSetActor do
     end
 
     it "writes to the most up to date version" do
+      expect(CurationConcerns.config.callback).to receive(:run).with(:after_create_fileset, file_set3, user)
       # using send(), because attach_file_to_work is private
       actor.send(:attach_file_to_work, work_v1, file_set3, {})
       expect(work_v1.members.size).to eq 3

--- a/spec/jobs/ingest_file_job_spec.rb
+++ b/spec/jobs/ingest_file_job_spec.rb
@@ -67,12 +67,4 @@ describe IngestFileJob do
       expect(VersionCommitter.where(version_id: versions.last.uri).pluck(:committer_login)).to eq [user2.user_key]
     end
   end
-
-  describe "the after_create_fileset callback" do
-    subject { CurationConcerns.config.callback }
-    it 'runs with file_set and user arguments' do
-      expect(subject).to receive(:run).with(:after_create_fileset, file_set, user)
-      described_class.perform_now(file_set, filename, 'image/png', user)
-    end
-  end
 end


### PR DESCRIPTION
The `:after_update_metadata` callback was getting triggered twice, so let the `BaseActor` take care of that (vs. the `FileSetActor`). Also, instead of triggering `:after_create_fileset` in the `IngestFileJob`, let the `FileSetActor` handle that itself.