### PR TITLE
Remove poorly named methods

### DIFF
--- a/app/indexers/curation_concerns/file_set_indexer.rb
+++ b/app/indexers/curation_concerns/file_set_indexer.rb
@@ -14,7 +14,6 @@ module CurationConcerns
         solr_doc[Solrizer.solr_name('file_format', :facetable)] = file_format
         solr_doc[Solrizer.solr_name(:file_size, STORED_INTEGER)] = object.file_size[0]
         solr_doc['all_text_timv'] = object.full_text.content
-        solr_doc[Solrizer.solr_name('generic_work_ids', :symbol)] = object.generic_work_ids unless object.generic_work_ids.empty?
         solr_doc['height_is'] = Integer(object.height.first) if object.height.present?
         solr_doc['width_is'] = Integer(object.width.first) if object.width.present?
         solr_doc[Solrizer.solr_name('mime_type', :stored_sortable)] = object.mime_type

--- a/app/models/concerns/curation_concerns/file_set/belongs_to_works.rb
+++ b/app/models/concerns/curation_concerns/file_set/belongs_to_works.rb
@@ -7,15 +7,6 @@ module CurationConcerns
         before_destroy :remove_representative_relationship
       end
 
-      def generic_works
-        in_objects # in_objects is provided by Hydra::PCDM::ObjectBehavior
-      end
-
-      # OPTIMIZE: We can load this from Solr much faster than loading the objects
-      def generic_work_ids
-        generic_works.map(&:id)
-      end
-
       # Returns the first parent object
       # This is a hack to handle things like FileSets inheriting access controls from their parent.  (see CurationConcerns::ParentContainer in app/controllers/concerns/curation_concers/parent_container.rb)
       def parent
@@ -29,16 +20,16 @@ module CurationConcerns
       # Files with sibling relationships
       # Returns all FileSets aggregated by any of the GenericWorks that aggregate the current object
       def related_files
-        generic_works = self.generic_works
-        return [] if generic_works.empty?
-        generic_works.flat_map { |work| work.file_sets.select { |file_set| file_set.id != id } }
+        parents = in_objects
+        return [] if parents.empty?
+        parents.flat_map { |work| work.file_sets.select { |file_set| file_set.id != id } }
       end
 
       # If any parent works are pointing at this object as their representative, remove that pointer.
       def remove_representative_relationship
-        generic_works = self.generic_works
-        return if generic_works.empty?
-        generic_works.each do |work|
+        parents = in_objects
+        return if parents.empty?
+        parents.each do |work|
           work.update(representative_id: nil) if work.representative_id == id
         end
       end

--- a/spec/actors/curation_concerns/file_set_actor_spec.rb
+++ b/spec/actors/curation_concerns/file_set_actor_spec.rb
@@ -30,7 +30,7 @@ describe CurationConcerns::FileSetActor do
 
     context 'when a work is not provided' do
       it "leaves the association blank" do
-        expect(subject.generic_works).to be_empty
+        expect(subject.in_works).to be_empty
       end
     end
 
@@ -38,7 +38,7 @@ describe CurationConcerns::FileSetActor do
       let(:work) { create(:generic_work) }
 
       it 'adds the generic file to the parent work' do
-        expect(subject.generic_works).to eq [work]
+        expect(subject.in_works).to eq [work]
         expect(work.reload.file_sets).to include(subject)
 
         # Confirming that date_uploaded and date_modified were set

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -416,7 +416,7 @@ describe FileSet do
     let(:work) { create(:work_with_one_file) }
     subject { work.file_sets.first.reload }
     it 'belongs to works' do
-      expect(subject.generic_works).to eq [work]
+      expect(subject.in_works).to eq [work]
     end
   end
 


### PR DESCRIPTION
@projecthydra/sufia-code-reviewers

GenericWork is not part of the model. Let's not have methods that imply
otherwise.