### PR TITLE
Nuke outdated references to GenericWorks and GenericFiles

### DIFF
--- a/app/actors/curation_concerns/file_set_actor.rb
+++ b/app/actors/curation_concerns/file_set_actor.rb
@@ -143,12 +143,12 @@ module CurationConcerns
       end
 
       def unlink_from_work
-        work = file_set.in_works.first
+        work = file_set.parent
         return unless work && (work.thumbnail_id == file_set.id || work.representative_id == file_set.id)
-        # This is required to clear the thumbnail_id and representative_id fields on the work
-        # and force it to be re-solrized. Although ActiveFedora::Aggregation clears the
-        # children nodes it leaves the GenericWork.thumbnail_id and GenericWork.representative_id
-        # fields in Solr populated.
+        # This is required to clear the thumbnail_id and representative_id
+        # fields on the work and force it to be re-solrized. Although
+        # ActiveFedora clears the children nodes it leaves the work's
+        # thumbnail_id and representative_id fields in Solr populated.
         work.thumbnail = nil if work.thumbnail_id == file_set.id
         work.representative = nil if work.representative_id == file_set.id
         work.save!

--- a/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
@@ -70,7 +70,7 @@ module CurationConcerns
     end
 
     def destroy
-      parent = @file_set.in_works.first
+      parent = @file_set.parent
       actor.destroy
       redirect_to [main_app, parent], notice: 'The file has been deleted.'
     end
@@ -194,7 +194,7 @@ module CurationConcerns
               if request.xhr?
                 render 'jq_upload', formats: 'json', content_type: 'text/html'
               else
-                redirect_to [main_app, @file_set.in_works.first]
+                redirect_to [main_app, @file_set.parent]
               end
             end
             format.json do
@@ -204,7 +204,7 @@ module CurationConcerns
         else
           msg = @file_set.errors.full_messages.join(', ')
           flash[:error] = msg
-          json_error "Error creating generic file #{file.original_filename}: #{msg}"
+          json_error "Error creating file #{file.original_filename}: #{msg}"
         end
       end
 

--- a/app/forms/curation_concerns/forms/collection_edit_form.rb
+++ b/app/forms/curation_concerns/forms/collection_edit_form.rb
@@ -18,7 +18,7 @@ module CurationConcerns
         model_class.validators_on(key).any? { |v| v.is_a? ActiveModel::Validations::PresenceValidator }
       end
 
-      # @return [Hash] All generic files in the collection, file.to_s is the key, file.id is the value
+      # @return [Hash] All FileSets in the collection, file.to_s is the key, file.id is the value
       def select_files
         Hash[all_files]
       end

--- a/app/helpers/curation_concerns/url_helper.rb
+++ b/app/helpers/curation_concerns/url_helper.rb
@@ -10,7 +10,7 @@ module CurationConcerns
       end
     end
 
-    # generated new GenericWork models get registered as curation concerns and need a
+    # generated models get registered as curation concerns and need a
     # track_model_path to render Blacklight-related views
     (['FileSet', 'Collection'] + CurationConcerns.config.registered_curation_concern_types).each do |concern|
       define_method("track_#{concern.constantize.model_name.singular_route_key}_path") { |*args| main_app.track_solr_document_path(*args) }

--- a/app/indexers/curation_concerns/file_set_indexer.rb
+++ b/app/indexers/curation_concerns/file_set_indexer.rb
@@ -14,7 +14,6 @@ module CurationConcerns
         solr_doc[Solrizer.solr_name('file_format', :facetable)] = file_format
         solr_doc[Solrizer.solr_name(:file_size, STORED_INTEGER)] = object.file_size[0]
         solr_doc['all_text_timv'] = object.full_text.content
-        solr_doc[Solrizer.solr_name('generic_work_ids', :symbol)] = object.generic_work_ids unless object.generic_work_ids.empty?
         solr_doc['height_is'] = Integer(object.height.first) if object.height.present?
         solr_doc['width_is'] = Integer(object.width.first) if object.width.present?
         solr_doc[Solrizer.solr_name('mime_type', :stored_sortable)] = object.mime_type

--- a/app/indexers/curation_concerns/work_indexer.rb
+++ b/app/indexers/curation_concerns/work_indexer.rb
@@ -3,10 +3,6 @@ module CurationConcerns
     include IndexesThumbnails
     def generate_solr_document
       super.tap do |solr_doc|
-        # We know that all the members of GenericWorks are FileSets so we can use
-        # member_ids which requires fewer Fedora API calls than file_set_ids.
-        # file_set_ids requires loading all the members from Fedora but member_ids
-        # looks just at solr
         solr_doc[Solrizer.solr_name('member_ids', :symbol)] = object.member_ids
         Solrizer.set_field(solr_doc, 'generic_type', 'Work', :facetable)
       end

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -17,10 +17,10 @@ class ImportUrlJob < ActiveJob::Base
     Tempfile.open(file_set.id.tr('/', '_')) do |f|
       copy_remote_file(file_set, f)
 
-      # reload the generic file once the data is copied since this is a long running task
+      # reload the FileSet once the data is copied since this is a long running task
       file_set.reload
 
-      # attach downloaded file to generic file stubbed out
+      # attach downloaded file to FileSet stubbed out
       if CurationConcerns::FileSetActor.new(file_set, user).create_content(f)
         # send message to user on download success
         CurationConcerns.config.callback.run(:after_import_url_success, file_set, user)

--- a/app/presenters/curation_concerns/presenter_factory.rb
+++ b/app/presenters/curation_concerns/presenter_factory.rb
@@ -3,7 +3,7 @@ module CurationConcerns
     class << self
       # @param [Array] ids the list of ids to load
       # @param [Class] klass the class of presenter to make
-      # @return [Array] presenters for the generic files in order of the ids
+      # @return [Array] presenters for the documents in order of the ids
       def build_presenters(ids, klass, ability)
         new(ids, klass, ability).build
       end

--- a/lib/curation_concerns/name.rb
+++ b/lib/curation_concerns/name.rb
@@ -3,11 +3,11 @@ module CurationConcerns
   # without changing the param key.
   #
   # Example:
-  #   name = CurationConcerns::Name.new(GenericWork)
+  #   name = CurationConcerns::Name.new(MyWork)
   #   name.param_key
-  #   # => 'generic_work'
+  #   # => 'my_work'
   #   name.route_key
-  #   # => 'curation_concerns_generic_works'
+  #   # => 'curation_concerns_my_works'
   #
   class Name < ActiveModel::Name
     def initialize(klass, namespace = nil, name = nil)

--- a/lib/curation_concerns/rails/routes.rb
+++ b/lib/curation_concerns/rails/routes.rb
@@ -71,9 +71,9 @@ module ActionDispatch::Routing
       ROUTE_OPTIONS = { 'curation_concerns' => { path: :concern } }.freeze
 
       # Namespaces routes appropriately
-      # @example namespaced_resources("curation_concerns/generic_work") is equivalent to
+      # @example namespaced_resources("curation_concerns/my_work") is equivalent to
       #   namespace "curation_concerns", path: :concern do
-      #     resources "generic_work", except: [:index]
+      #     resources "my_work", except: [:index]
       #   end
       def namespaced_resources(target, opts = {}, &block)
         if target.include?('/')

--- a/lib/generators/curation_concerns/work/USAGE
+++ b/lib/generators/curation_concerns/work/USAGE
@@ -1,6 +1,5 @@
 Description:
-  This generator creates the necessary files for work that extends
-  CurationConcerns's GenericWork.
+  This generator creates the necessary files for new work types.
 
 Example:
   rails generate curation_concerns:work ScholarlyPaper

--- a/lib/generators/curation_concerns/work/templates/README
+++ b/lib/generators/curation_concerns/work/templates/README
@@ -4,9 +4,9 @@ After creating your work you may wish to:
 
   1. Add custom views:
 
-      Your newly created work's controller extends from
-      CurationConcerns::GenericWorksController; This means that it will use the
-      views found in CurationConcerns::Engine.root/app/views/curation_concerns/base.
+      By default, the views found in
+      CurationConcerns::Engine.root/app/views/curation_concerns/base
+      will be used.
 
   2. Modify the model, actor, form or presenter.
 

--- a/spec/actors/curation_concerns/file_set_actor_spec.rb
+++ b/spec/actors/curation_concerns/file_set_actor_spec.rb
@@ -30,15 +30,15 @@ describe CurationConcerns::FileSetActor do
 
     context 'when a work is not provided' do
       it "leaves the association blank" do
-        expect(subject.generic_works).to be_empty
+        expect(subject.parents).to be_empty
       end
     end
 
     context 'when a work is provided' do
       let(:work) { create(:generic_work) }
 
-      it 'adds the generic file to the parent work' do
-        expect(subject.generic_works).to eq [work]
+      it 'adds the FileSet to the parent work' do
+        expect(subject.parents).to eq [work]
         expect(work.reload.file_sets).to include(subject)
 
         # Confirming that date_uploaded and date_modified were set

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -81,7 +81,7 @@ describe CurationConcerns::FileSetsController do
         it 'errors out of create after on continuous rsolr error' do
           xhr :post, :create, parent_id: parent, file_set: { files: [file] },
                               permission: { group: { 'public' => 'read' } }, terms_of_service: '1'
-          expect(response.body).to include('Error creating generic file image.png')
+          expect(response.body).to include('Error creating file image.png')
         end
       end
     end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
 
     factory :work_with_one_file do
       before(:create) do |work, evaluator|
-        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained Generic File'], filename: 'filename.pdf')
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], filename: 'filename.pdf')
       end
     end
 

--- a/spec/features/update_file_spec.rb
+++ b/spec/features/update_file_spec.rb
@@ -20,7 +20,7 @@ feature 'Editing attached files' do
     attach_file('Upload a file', fixture_file_path('files/image.png'))
     click_button 'Update Attached File'
 
-    expect(page).to have_content 'The file A Contained Generic File has been updated.'
+    expect(page).to have_content 'The file A Contained FileSet has been updated.'
 
     # TODO: this stuff belongs in an Actor or Controller test:
     file_set.reload

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -416,7 +416,7 @@ describe FileSet do
     let(:work) { create(:work_with_one_file) }
     subject { work.file_sets.first.reload }
     it 'belongs to works' do
-      expect(subject.generic_works).to eq [work]
+      expect(subject.parents).to eq [work]
     end
   end
 


### PR DESCRIPTION
Paraphrasing #760's rationale: GenericWork is not part of CurationConcerns models. Let's not have methods that imply otherwise.

Note that there are still a bunch of files under `spec/` that continue to reference GWs, but that's because `GenericWork` is the CC work generated by the test app generator. I don't care about those.

Closes #760.