### PR TITLE
Tidying up Rubocop declarations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,24 +9,12 @@ AllCops:
     - 'script/**/*'
     - 'vendor/**/*'
     - '.internal_test_app/**/*'
-    - 'app/models/concerns/curation_concerns/file_set/export.rb'
 
 Rails:
   Enabled: true
 
-Performance/RedundantBlockCall:
-  # We can remove this exclusion when this commit is released:
-  # https://github.com/bbatsov/rubocop/commit/7df382531db4f66cd9872a4f478bd486d6ce6712
-  Exclude:
-    - 'lib/curation_concerns/null_logger.rb'
-
 Performance/RedundantMerge:
   Enabled: false
-
-Lint/AssignmentInCondition:
-  Exclude:
-    - 'app/services/curation_concerns/persist_derivatives.rb'
-    - 'app/actors/curation_concerns/file_set_actor.rb'
 
 Metrics/LineLength:
   Enabled: false
@@ -38,18 +26,11 @@ Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/services/curation_concerns/file_set_audit_service.rb'
     - 'app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb'
-    - 'app/helpers/curation_concerns/curation_concerns_helper_behavior.rb'
-    - 'app/helpers/curation_concerns/attribute_helper.rb'
-    - 'app/actors/curation_concerns/file_set_actor.rb'
-    - 'app/actors/curation_concerns/work_actor_behavior.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:
     - 'app/services/curation_concerns/file_set_audit_service.rb'
     - 'app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb'
-    - 'app/helpers/curation_concerns/curation_concerns_helper_behavior.rb'
-    - 'app/helpers/curation_concerns/attribute_helper.rb'
-    - 'app/actors/curation_concerns/file_set_actor.rb'
 
 Metrics/MethodLength:
   Enabled: false
@@ -63,10 +44,7 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Exclude:
     - 'app/controllers/concerns/curation_concerns/curation_concern_controller.rb'
-    - 'app/controllers/concerns/curation_concerns/users_controller_behavior.rb'
-    - 'app/controllers/concerns/curation_concerns/catalog_controller.rb'
     - 'app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb'
-    - 'app/helpers/curation_concerns/curation_concerns_helper_behavior.rb'
     - 'app/models/concerns/curation_concerns/solr_document_behavior.rb'
     - 'app/controllers/concerns/curation_concerns/collections_controller_behavior.rb'
 
@@ -129,9 +107,6 @@ Style/HashSyntax:
 
 Style/PredicateName:
   Exclude:
-    - 'app/helpers/curation_concerns/curation_concerns_helper_behavior.rb'
-    - 'app/controllers/concerns/curation_concerns/controller.rb'
-    - 'app/helpers/curation_concerns/collections_helper.rb'
     - 'app/helpers/curation_concerns/collections_helper_behavior.rb'
 
 Style/GlobalVars:


### PR DESCRIPTION
Removing files from the exclusion list. In all cases, the violations no
longer occur.