### PR TITLE
Method for updating rights and supporting retired rights.

### DIFF
--- a/app/services/rights_service.rb
+++ b/app/services/rights_service.rb
@@ -3,12 +3,14 @@ module RightsService
   self.authority = Qa::Authorities::Local.subauthority_for('rights')
 
   def self.select_options
-    authority.all.map do |element|
-      [element[:label], element[:id]]
-    end
+    active_elements.map { |e| [e[:label], e[:id]] }
   end
 
   def self.label(id)
     authority.find(id).fetch('term')
+  end
+
+  def self.active_elements
+    authority.all.select { |e| authority.find(e[:id])[:active] }
   end
 end

--- a/lib/generators/curation_concerns/templates/config/authorities/rights.yml
+++ b/lib/generators/curation_concerns/templates/config/authorities/rights.yml
@@ -1,19 +1,28 @@
 terms:
     - id: http://creativecommons.org/licenses/by/3.0/us/
       term: Attribution 3.0 United States
+      active: true
     - id: http://creativecommons.org/licenses/by-sa/3.0/us/
       term: Attribution-ShareAlike 3.0 United States
+      active: true
     - id: http://creativecommons.org/licenses/by-nc/3.0/us/
       term: Attribution-NonCommercial 3.0 United States
+      active: true
     - id: http://creativecommons.org/licenses/by-nd/3.0/us/
       term: Attribution-NoDerivs 3.0 United States
+      active: true
     - id: http://creativecommons.org/licenses/by-nc-nd/3.0/us/
       term: Attribution-NonCommercial-NoDerivs 3.0 United States
+      active: true
     - id: http://creativecommons.org/licenses/by-nc-sa/3.0/us/
       term: Attribution-NonCommercial-ShareAlike 3.0 United States
+      active: true
     - id: http://creativecommons.org/publicdomain/mark/1.0/
       term: Public Domain Mark 1.0
+      active: true
     - id: http://creativecommons.org/publicdomain/zero/1.0/
       term: CC0 1.0 Universal
+      active: true
     - id: http://www.europeana.eu/portal/rights/rr-r.html
       term: All rights reserved
+      active: true

--- a/spec/fixtures/authorities/rights.yml
+++ b/spec/fixtures/authorities/rights.yml
@@ -1,0 +1,13 @@
+terms:
+    - id: demo_id_01
+      term: First Active Term
+      active: true
+    - id: demo_id_02
+      term: Second Active Term
+      active: true
+    - id: demo_id_03
+      term: Third is an Inactive Term
+      active: false
+    - id: demo_id_04
+      term: Fourth is an Inactive Term
+      active: false

--- a/spec/services/rights_service_spec.rb
+++ b/spec/services/rights_service_spec.rb
@@ -1,17 +1,29 @@
 require 'spec_helper'
 
 describe RightsService do
-  describe "select_options" do
-    subject { described_class.select_options }
+  before do
+    # Configure QA to use fixtures
+    qa_fixtures = { local_path: File.expand_path('../../fixtures/authorities', __FILE__) }
+    stub_const("Qa::Authorities::LocalSubauthority::AUTHORITIES_CONFIG", qa_fixtures)
+  end
 
-    it "has a select list" do
-      expect(subject.first).to eq ["Attribution 3.0 United States", "http://creativecommons.org/licenses/by/3.0/us/"]
+  describe "#select_options" do
+    it "returns active terms" do
+      expect(described_class.select_options).to include(["First Active Term", "demo_id_01"], ["Second Active Term", "demo_id_02"])
+    end
+
+    it "does not return inactive terms" do
+      expect(described_class.select_options).not_to include(["Third is an Inactive Term", "demo_id_03"], ["Fourth is an Inactive Term", "demo_id_04"])
     end
   end
 
-  describe "label" do
-    subject { described_class.label("http://www.europeana.eu/portal/rights/rr-r.html") }
+  describe "#label" do
+    it "resolves for ids of active terms" do
+      expect(described_class.label('demo_id_01')).to eq("First Active Term")
+    end
 
-    it { is_expected.to eq 'All rights reserved' }
+    it "resolves for ids of inactive terms" do
+      expect(described_class.label('demo_id_03')).to eq("Third is an Inactive Term")
+    end
   end
 end


### PR DESCRIPTION
Fixes #747

Allow adding new rights and marking retired rights as inactive.  Still resolve labels for both.

This supports resolving the labels for rights while not offering them as current choices to the users.

Changes proposed in this pull request:
* Add active attribute
* Make rights service utilize active attribute of terms.
* Add fixture file of dummy rights for testing.
* Update rights tests to use fixture file.

@projecthydra/sufia-code-reviewers
