### PR TITLE
Preferring `Array.wrap()` over `Array()`

### DIFF
--- a/app/actors/curation_concerns/base_actor.rb
+++ b/app/actors/curation_concerns/base_actor.rb
@@ -50,7 +50,7 @@ module CurationConcerns
       end
 
       def apply_save_data_to_curation_concern(attributes)
-        attributes[:rights] = Array(attributes[:rights]) if attributes.key? :rights
+        attributes[:rights] = Array.wrap(attributes[:rights]) if attributes.key? :rights
         remove_blank_attributes!(attributes)
         curation_concern.attributes = attributes.symbolize_keys
         curation_concern.date_modified = CurationConcerns::TimeService.time_in_utc

--- a/app/forms/curation_concerns/forms/work_form.rb
+++ b/app/forms/curation_concerns/forms/work_form.rb
@@ -56,7 +56,7 @@ module CurationConcerns
         # Overriden to cast 'rights' to an array
         def sanitize_params(form_params)
           super.tap do |params|
-            params['rights'] = Array(params['rights']) if params.key?('rights')
+            params['rights'] = Array.wrap(params['rights']) if params.key?('rights')
           end
         end
       end

--- a/app/models/concerns/curation_concerns/serializers.rb
+++ b/app/models/concerns/curation_concerns/serializers.rb
@@ -2,9 +2,9 @@ module CurationConcerns
   module Serializers
     def to_s
       if title.present?
-        Array(title).join(' | ')
+        Array.wrap(title).join(' | ')
       elsif label.present?
-        Array(label).join(' | ')
+        Array.wrap(label).join(' | ')
       else
         'No Title'
       end

--- a/app/models/concerns/curation_concerns/solr_document_behavior.rb
+++ b/app/models/concerns/curation_concerns/solr_document_behavior.rb
@@ -37,7 +37,7 @@ module CurationConcerns
     end
 
     def human_readable_type
-      Array(self[Solrizer.solr_name('human_readable_type', :stored_searchable)]).first
+      Array.wrap(self[Solrizer.solr_name('human_readable_type', :stored_searchable)]).first
     end
 
     def representative_id
@@ -58,24 +58,24 @@ module CurationConcerns
     end
 
     def depositor(default = '')
-      val = Array(self[Solrizer.solr_name('depositor')]).first
+      val = Array.wrap(self[Solrizer.solr_name('depositor')]).first
       val.present? ? val : default
     end
 
     def title
-      Array(self[Solrizer.solr_name('title')]).first
+      Array.wrap(self[Solrizer.solr_name('title')]).first
     end
 
     def description
-      Array(self[Solrizer.solr_name('description')]).first
+      Array.wrap(self[Solrizer.solr_name('description')]).first
     end
 
     def label
-      Array(self[Solrizer.solr_name('label')]).first
+      Array.wrap(self[Solrizer.solr_name('label')]).first
     end
 
     def file_format
-      Array(self[Solrizer.solr_name('file_format')]).first
+      Array.wrap(self[Solrizer.solr_name('file_format')]).first
     end
 
     def creator

--- a/app/models/concerns/curation_concerns/work_behavior.rb
+++ b/app/models/concerns/curation_concerns/work_behavior.rb
@@ -34,7 +34,7 @@ module CurationConcerns::WorkBehavior
 
   def to_s
     if title.present?
-      Array(title).join(' | ')
+      Array.wrap(title).join(' | ')
     else
       'No Title'
     end

--- a/app/presenters/curation_concerns/file_set_presenter.rb
+++ b/app/presenters/curation_concerns/file_set_presenter.rb
@@ -25,11 +25,11 @@ module CurationConcerns
              :depositor, :tags, :title_or_label, to: :solr_document
 
     def page_title
-      Array(solr_document['label_tesim']).first
+      Array.wrap(solr_document['label_tesim']).first
     end
 
     def link_name
-      current_ability.can?(:read, id) ? Array(solr_document['label_tesim']).first : 'File'
+      current_ability.can?(:read, id) ? Array.wrap(solr_document['label_tesim']).first : 'File'
     end
   end
 end

--- a/app/renderers/curation_concerns/attribute_renderer.rb
+++ b/app/renderers/curation_concerns/attribute_renderer.rb
@@ -25,7 +25,7 @@ module CurationConcerns
       return markup if !values.present? && !options[:include_empty]
       markup << %(<tr><th>#{label}</th>\n<td><ul class='tabular'>)
       attributes = microdata_object_attributes(field).merge(class: "attribute #{field}")
-      Array(values).each do |value|
+      Array.wrap(values).each do |value|
         markup << "<li#{html_attributes(attributes)}>#{attribute_value_to_html(value.to_s)}</li>"
       end
       markup << %(</ul></td></tr>)

--- a/app/search_builders/curation_concerns/filter_by_type.rb
+++ b/app/search_builders/curation_concerns/filter_by_type.rb
@@ -22,14 +22,14 @@ module CurationConcerns
       end
 
       def work_clauses
-        return [] if blacklight_params.key?(:f) && Array(blacklight_params[:f][:generic_type_sim]).include?('Collection')
+        return [] if blacklight_params.key?(:f) && Array.wrap(blacklight_params[:f][:generic_type_sim]).include?('Collection')
         work_types.map do |klass|
           ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: klass.to_class_uri)
         end
       end
 
       def collection_clauses
-        return [] if blacklight_params.key?(:f) && Array(blacklight_params[:f][:generic_type_sim]).include?('Work')
+        return [] if blacklight_params.key?(:f) && Array.wrap(blacklight_params[:f][:generic_type_sim]).include?('Work')
         [ActiveFedora::SolrQueryBuilder.construct_query_for_rel(has_model: ::Collection.to_class_uri)]
       end
   end

--- a/lib/curation_concerns/configuration.rb
+++ b/lib/curation_concerns/configuration.rb
@@ -142,7 +142,7 @@ module CurationConcerns
     # Registers the given curation concern model in the configuration
     # @param [Array<Symbol>,Symbol] curation_concern_types
     def register_curation_concern(*curation_concern_types)
-      Array(curation_concern_types).flatten.compact.each do |cc_type|
+      Array.wrap(curation_concern_types).flatten.compact.each do |cc_type|
         unless @registered_concerns.include?(cc_type)
           @registered_concerns << cc_type
         end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -27,7 +27,7 @@ describe FileSet do
   context 'when it is initialized' do
     it 'has empty arrays for all the properties' do
       subject.attributes.each do |_k, v|
-        expect(Array(v)).to eq([])
+        expect(Array.wrap(v)).to eq([])
       end
     end
   end


### PR DESCRIPTION
## Preferring `Array.wrap()` over `Array()`

@5e71eb2b8592117cbb4ccdaa5a8a65ac4aba49fb

`Array()` is a Ruby core method for coercing objects into an Array.
`Array.wrap()` is an ActiveSupport method that behaves a bit more as
expected.

The primary example of why to prefer `Array.wrap` is the following:

```ruby
now = Time.now
Array.wrap(now) == [now]
=> true
Array(now) == [now]
=> false
Array(now)
=> [43, 53, 13, 5, 5, 2016, 4, 126, true, "EDT"]
```
