### PR TITLE
Characterization metadata now stored in original_file

### DIFF
--- a/app/models/concerns/curation_concerns/characterization.rb
+++ b/app/models/concerns/curation_concerns/characterization.rb
@@ -1,0 +1,41 @@
+# This module points the FileSet to the location of the technical metdata.
+# By default, the file holding the metadata is :original_file and the terms
+# are listed under ::characterization_terms.
+# Implementations may define their own terms or use a different source file, but
+# any terms must be set on the ::characterization_proxy by the Hydra::Works::CharacterizationService
+#
+# class MyFileSet
+#   include CurationConcerns::FileSetBehavior
+# end
+#
+# MyFileSet.characterization_proxy = :master_file
+# MyFileSet.characterization_terms = [:term1, :term2, :term3]
+module CurationConcerns
+  module Characterization
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :characterization_terms, :characterization_proxy
+      self.characterization_terms = [
+        :format_label, :file_size, :height, :width, :filename, :well_formed,
+        :page_count, :file_title, :last_modified, :original_checksum, :mime_type
+      ]
+      self.characterization_proxy = :original_file
+
+      delegate(*characterization_terms, to: :characterization_proxy)
+
+      def characterization_proxy
+        send(self.class.characterization_proxy) || NullCharacterizationProxy.new
+      end
+    end
+
+    class NullCharacterizationProxy
+      def method_missing(*_args)
+        []
+      end
+
+      def mime_type
+      end
+    end
+  end
+end

--- a/app/models/concerns/curation_concerns/file_set_behavior.rb
+++ b/app/models/concerns/curation_concerns/file_set_behavior.rb
@@ -9,7 +9,7 @@ module CurationConcerns
     include CurationConcerns::BasicMetadata
     include Hydra::Works::FileSetBehavior
     include Hydra::Works::VirusCheck
-    include Hydra::Works::Characterization
+    include CurationConcerns::Characterization
     include Hydra::WithDepositor
     include CurationConcerns::Serializers
     include CurationConcerns::Noid

--- a/app/services/curation_concerns/thumbnail_path_service.rb
+++ b/app/services/curation_concerns/thumbnail_path_service.rb
@@ -19,7 +19,7 @@ module CurationConcerns
 
       def fetch_thumbnail(object)
         return object if object.thumbnail_id == object.id
-        ::FileSet.load_instance_from_solr(object.thumbnail_id)
+        ::FileSet.find(object.thumbnail_id)
       rescue ActiveFedora::ObjectNotFoundError
         Rails.logger.error("Couldn't find thumbnail #{object.thumbnail_id} for #{object.id}")
         nil

--- a/app/views/curation_concerns/base/_representative_media.html.erb
+++ b/app/views/curation_concerns/base/_representative_media.html.erb
@@ -1,4 +1,4 @@
-<% if presenter.representative_id.present? && (fs = ::FileSet.load_instance_from_solr(presenter.representative_id)) %>
+<% if presenter.representative_id.present? && (fs = ::FileSet.find(presenter.representative_id)) %>
   <%= media_display fs %>
 <% else %>
   <%= image_tag 'nope.png', class: "canonical-image" %>

--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -29,10 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sprockets-es6'
   spec.add_dependency 'kaminari_route_prefix', '~> 0.0.1'
   spec.add_dependency 'active_attr'
-  spec.add_dependency 'hydra-works', '~> 0.8', '>= 0.8.1'
-  # This allows bundler to resolve a dependency tree.
-  # TODO: I suspect we can remove it when hydra-pcdm 0.8.0 is released.
-  spec.add_dependency 'hydra-pcdm', '>= 0.8.0.beta1', '< 1'
+  spec.add_dependency 'hydra-works', '>= 0.10.0'
   spec.add_dependency 'active_fedora-noid', '~> 1.0'
   spec.add_dependency 'qa', '~> 0.5'
   spec.add_dependency 'redlock', '~> 0.1.2'

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -49,13 +49,13 @@ describe CurationConcerns::FileSetsController do
       context 'when the file has a virus' do
         before do
           allow(subject).to receive(:warn) # suppress virus warnings
-          allow(ClamAV.instance).to receive(:scanfile).and_return('EL CRAPO VIRUS')
+          allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?) { true }
           of = subject.build_original_file
           of.content = File.open(file_path)
         end
         it 'populates the errors hash during validation' do
           expect(subject).to_not be_valid
-          expect(subject.errors.messages[:base].first).to match(/A virus was found in .*: EL CRAPO VIRUS/)
+          expect(subject.errors.messages[:base].first).to eq "Failed to verify uploaded file is not a virus"
         end
       end
 

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
 
     factory :work_with_one_file do
       before(:create) do |work, evaluator|
-        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], filename: 'filename.pdf')
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'])
       end
     end
 

--- a/spec/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/file_set_indexer_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe CurationConcerns::FileSetIndexer do
+  include CurationConcerns::FactoryHelpers
+
   let(:file_set) do
     FileSet.new(
       id: 'foo123',
@@ -19,20 +21,21 @@ describe CurationConcerns::FileSetIndexer do
       resource_type: ['Book'],
       identifier: ['urn:isbn:1234567890'],
       based_near: ['Medina, Saudi Arabia'],
-      related_url: ['http://example.org/TheWork/'],
-      mime_type: 'image/jpeg',
-      format_label: ['JPEG Image']) do |gf|
+      related_url: ['http://example.org/TheWork/']) do |gf|
         gf.full_text.content = 'abcxyz'
-        gf.height = ['500']
-        gf.width = ['600']
       end
   end
 
   let(:mock_file) do
-    mock_model("MockFile",
-               content: "asdf",
-               digest: ["urn:sha1:f794b23c0c6fe1083d0ca8b58261a078cd968967"]
-              )
+    mock_file_factory(
+      content: "asdf",
+      digest: ["urn:sha1:f794b23c0c6fe1083d0ca8b58261a078cd968967"],
+      mime_type: 'image/jpeg',
+      format_label: ['JPEG Image'],
+      height: ['500'],
+      width: ['600'],
+      file_size: ['12']
+    )
   end
   let(:indexer) { described_class.new(file_set) }
 

--- a/spec/models/curation_concerns/collection_behavior_spec.rb
+++ b/spec/models/curation_concerns/collection_behavior_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'rspec/active_model/mocks'
 
 describe CurationConcerns::CollectionBehavior do
+  include CurationConcerns::FactoryHelpers
+
   # All behavior for Collection are defined in CC::CollectionBehavior, so we use
   # a Collection instance to test.
   let(:collection) { FactoryGirl.build(:collection) }
@@ -31,13 +33,20 @@ describe CurationConcerns::CollectionBehavior do
     # Calculating the size of the Collection should only hit Solr.
     # This base case querries solr in an integration test
     context 'with indexed Works and FileSets', :integration do
-      let(:file1) { FactoryGirl.build(:file_set, file_size: ['100']) }
-      let(:file2) { FactoryGirl.build(:file_set, file_size: ['100']) }
-      let(:file3) { FactoryGirl.build(:file_set, file_size: ['9000'], id: 'fumid') }
+      let(:file1) { FactoryGirl.build(:file_set) }
+      let(:file2) { FactoryGirl.build(:file_set) }
+      let(:file3) { FactoryGirl.build(:file_set, id: 'fumid') }
       let(:work1) { FactoryGirl.build(:generic_work) }
       let(:work2) { FactoryGirl.build(:generic_work) }
       let(:work3) { FactoryGirl.build(:generic_work, id: 'dumid') }
+      let(:of1)   { mock_file_factory(file_size: ['100']) }
+      let(:of2)   { mock_file_factory(file_size: ['100']) }
+      let(:of3)   { mock_file_factory(file_size: ['9000']) }
+
       before do
+        allow(file1).to receive(:original_file).and_return(of1)
+        allow(file2).to receive(:original_file).and_return(of2)
+        allow(file3).to receive(:original_file).and_return(of3)
         # Save collection to get ids
         collection.save
         # Create relationships so member_ids are created

--- a/spec/services/thumbnail_path_service_spec.rb
+++ b/spec/services/thumbnail_path_service_spec.rb
@@ -1,35 +1,39 @@
 require 'spec_helper'
 
 describe CurationConcerns::ThumbnailPathService do
+  include CurationConcerns::FactoryHelpers
+
   subject { described_class.call(object) }
 
   context "with a FileSet" do
-    let(:object) { FileSet.new(id: '999', mime_type: mime_type) }
-    let(:mime_type) { 'image/jpeg' }
+    let(:object) { build(:file_set, id: '999') }
+    before { allow(object).to receive(:original_file).and_return(original_file) }
     context "that has a thumbnail" do
-      before do
-        allow(File).to receive(:exist?).and_return(true)
-      end
+      let(:original_file) { mock_file_factory(mime_type: 'image/jpeg') }
+      before { allow(File).to receive(:exist?).and_return(true) }
       it { is_expected.to eq '/downloads/999?file=thumbnail' }
     end
 
     context "that is an audio" do
-      let(:mime_type) { 'audio/x-wav' }
+      let(:original_file) { mock_file_factory(mime_type: 'audio/x-wav') }
       it { is_expected.to match %r{/assets/audio-.+.png} }
     end
 
     context "that has no thumbnail" do
+      let(:original_file) { mock_model('MockFile', mime_type: nil) }
       it { is_expected.to match %r{/assets/default-.+.png} }
     end
   end
 
   context "with a Work" do
     context "that has a thumbnail" do
-      let(:object) { GenericWork.new(thumbnail_id: '999') }
-      let(:representative) { FileSet.new(id: '777') }
+      let(:object)         { GenericWork.new(thumbnail_id: '999') }
+      let(:representative) { build(:file_set, id: '777') }
+      let(:original_file)  { mock_file_factory(mime_type: 'image/jpeg') }
       before do
         allow(File).to receive(:exist?).and_return(true)
-        allow(FileSet).to receive(:load_instance_from_solr).with('999').and_return(representative)
+        allow(FileSet).to receive(:find).with('999').and_return(representative)
+        allow(representative).to receive(:original_file).and_return(original_file)
       end
 
       it { is_expected.to eq '/downloads/999?file=thumbnail' }

--- a/spec/support/curation_concerns/factory_helpers.rb
+++ b/spec/support/curation_concerns/factory_helpers.rb
@@ -11,5 +11,23 @@ module CurationConcerns
         let(:public_work_factory_name) { "public_#{curation_concern_type_underscore}".to_sym }
       end
     end
+
+    def mock_file_factory(opts = {})
+      mock_model('MockFile',
+                 mime_type:         opts.fetch(:mime_type, 'text/plain'),
+                 content:           opts.fetch(:content, 'content'),
+                 file_size:         opts.fetch(:file_size, []),
+                 format_label:      opts.fetch(:format_label, []),
+                 height:            opts.fetch(:height, []),
+                 width:             opts.fetch(:width, []),
+                 filename:          opts.fetch(:filename, []),
+                 well_formed:       opts.fetch(:well_formed, []),
+                 page_count:        opts.fetch(:page_count, []),
+                 file_title:        opts.fetch(:file_title, []),
+                 last_modified:     opts.fetch(:last_modified, []),
+                 original_checksum: opts.fetch(:original_checksum, []),
+                 digest:            opts.fetch(:digest, [])
+                )
+    end
   end
 end


### PR DESCRIPTION
Relates to projecthydra/sufia#1894

Uses changes in HydraWorks to keep technical metadata on the original_file, but accessible through a proxy mechanism defined in `CurationConcerns::Characterization`

Changes proposed in this pull request:
* technical metadata is delegated to `original_file`
* `FileSet.find` must be used in place of `FileSet.load_instance_from_solr` in certain cases

@projecthydra/sufia-code-reviewers
