### PR TITLE
Make the ingest activejob queue name configurable

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,5 +1,5 @@
 class CharacterizeJob < ActiveJob::Base
-  queue_as :ingest
+  queue_as CurationConcerns.config.ingest_queue_name
 
   # @param [FileSet] file_set
   # @param [String] filename a local path for the file to characterize. By using this, we don't have to pull a copy out of fedora.

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -1,5 +1,5 @@
 class CreateDerivativesJob < ActiveJob::Base
-  queue_as :ingest
+  queue_as CurationConcerns.config.ingest_queue_name
 
   # @param [FileSet] file_set
   # @param [String] file_name

--- a/app/jobs/import_url_job.rb
+++ b/app/jobs/import_url_job.rb
@@ -3,7 +3,7 @@ require 'uri'
 require 'tempfile'
 
 class ImportUrlJob < ActiveJob::Base
-  queue_as :ingest
+  queue_as CurationConcerns.config.ingest_queue_name
 
   before_enqueue do |job|
     log = job.arguments.last

--- a/app/jobs/ingest_file_job.rb
+++ b/app/jobs/ingest_file_job.rb
@@ -1,5 +1,5 @@
 class IngestFileJob < ActiveJob::Base
-  queue_as :ingest
+  queue_as CurationConcerns.config.ingest_queue_name
 
   # @param [FileSet] file_set
   # @param [String] filename

--- a/app/jobs/ingest_local_file_job.rb
+++ b/app/jobs/ingest_local_file_job.rb
@@ -1,5 +1,5 @@
 class IngestLocalFileJob < ActiveJob::Base
-  queue_as :ingest
+  queue_as CurationConcerns.config.ingest_queue_name
 
   # @param [FileSet] file_set
   # @param [String] path

--- a/lib/curation_concerns/configuration.rb
+++ b/lib/curation_concerns/configuration.rb
@@ -127,6 +127,13 @@ module CurationConcerns
       @lock_retry_delay ||= 200 # milliseconds
     end
 
+    # @!attribute [w] ingest_queue_name
+    #   ActiveJob queue to handle ingest-like jobs.
+    attr_writer :ingest_queue_name
+    def ingest_queue_name
+      @ingest_queue_name ||= :ingest
+    end
+
     callback.enable :after_create_concern, :after_create_fileset,
                     :after_update_content, :after_revert_content,
                     :after_update_metadata, :after_import_local_file_success,


### PR DESCRIPTION
I'm on the fence whether this is worth the added complexity. For hybox, we're thinking about pushing all jobs into the same queue so we can manage and scale it easily.

I'm also tempted to make the default to just use the Rails default queue, and make using a separate queue an additional configuration.