### PR TITLE
Remove duplicate include in CurationConcerns::Collection

### DIFF
--- a/app/models/concerns/curation_concerns/collection.rb
+++ b/app/models/concerns/curation_concerns/collection.rb
@@ -2,7 +2,6 @@ module CurationConcerns
   module Collection
     extend ActiveSupport::Concern
     extend Deprecation
-    include Hydra::Works::CollectionBehavior
     include Hydra::WithDepositor # for access to apply_depositor_metadata
     include Hydra::AccessControls::Permissions
     include CurationConcerns::RequiredMetadata


### PR DESCRIPTION
Looks like Hydra::Works::CollectionBehavior got included twice here when collections got merged in.  If I'm wrong, feel free to close and delete this PR.  


Changes proposed in this pull request:
* Delete the duplication of `include Hydra::Works::CollectionBehavior` in CurationConcerns::Collection, leaves the second copy (expand the fold to view)

@projecthydra/sufia-code-reviewers
