### PR TITLE
Put the ResolrizeJob on the default queue

### DIFF
--- a/app/jobs/resolrize_job.rb
+++ b/app/jobs/resolrize_job.rb
@@ -1,6 +1,4 @@
 class ResolrizeJob < ActiveJob::Base
-  queue_as :resolrize
-
   def perform
     ActiveFedora::Base.reindex_everything
   end


### PR DESCRIPTION
In #784, we collapsed most of the job queues into `:ingest` or the default queue. We were uncertain what to do with the `ResolrizeJob` (which is only invoked via a Rake task). It seems like we have two choices here:

- a new queue, with a slightly more abstract name (names welcome..)
- the default queue, recognizing it could occupy a worker thread.

The default queue seems to be the least painful for new or small-scale adopters, although larger adopters may want to configure this in an initializer.