### PR TITLE
WIP: Use the characterization proxy for the CharacterizeJob

### DIFF
--- a/app/jobs/characterize_job.rb
+++ b/app/jobs/characterize_job.rb
@@ -1,11 +1,28 @@
 class CharacterizeJob < ActiveJob::Base
   queue_as CurationConcerns.config.ingest_queue_name
 
+  before_perform :wait_for_content # do |job|
+  #  byebug
+  # end
+
+  DEFAULT_WAIT_TIME = 0.01
+  DEFAULT_WAIT_COUNT = 10
+
   # @param [FileSet] file_set
   # @param [String] filename a local path for the file to characterize. By using this, we don't have to pull a copy out of fedora.
+  # @param [Hash] opts hash of options for wait_for_content: :wait_time, :wait_count
   def perform(file_set, filename)
-    Hydra::Works::CharacterizationService.run(file_set, filename)
+    Hydra::Works::CharacterizationService.run(file_set.characterization_proxy, filename)
     file_set.save!
     CreateDerivativesJob.perform_later(file_set, filename)
+  end
+
+  def wait_for_content
+    count = 0
+    until arguments.first.original_file.content
+      sleep DEFAULT_WAIT_TIME
+      count += 1
+      raise(IOError, 'no content found for :original_file') if count == DEFAULT_WAIT_COUNT
+    end
   end
 end

--- a/spec/jobs/characterize_job_spec.rb
+++ b/spec/jobs/characterize_job_spec.rb
@@ -1,18 +1,32 @@
 require 'spec_helper'
 
 describe CharacterizeJob do
-  let(:file_set) { FileSet.new(id: file_set_id) }
-  let(:file_set_id) { 'abc123' }
-  let(:filename) { double }
+  let(:file_set)      { FileSet.new(id: file_set_id) }
+  let(:file_set_id)   { 'abc123' }
+  let(:filename)      { double }
+  let(:original_file) { mock_model('MockFile') }
 
   before do
+    allow(file_set).to receive(:original_file).and_return(original_file)
     allow(FileSet).to receive(:find).with(file_set_id).and_return(file_set)
   end
 
-  it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
-    expect(Hydra::Works::CharacterizationService).to receive(:run).with(file_set, filename)
-    expect(file_set).to receive(:save!)
-    expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, filename)
-    described_class.perform_now file_set, filename
+  context 'when original file is present' do
+    before { allow(original_file).to receive(:content).and_return('stuff') }
+    it 'runs Hydra::Works::CharacterizationService and creates a CreateDerivativesJob' do
+      expect(Hydra::Works::CharacterizationService).to receive(:run).with(original_file, filename)
+      expect(file_set).to receive(:save!)
+      expect(CreateDerivativesJob).to receive(:perform_later).with(file_set, filename)
+      described_class.perform_now file_set, filename
+    end
+  end
+
+  context 'when original file is not present' do
+    let(:job) { described_class.new(file_set, filename) }
+    before { allow(original_file).to receive(:content).and_return(nil) }
+    it 'waits for the file then fails after a number of tries' do
+      expect(job).to receive(:sleep).with(described_class::DEFAULT_WAIT_TIME).exactly(described_class::DEFAULT_WAIT_COUNT).times
+      expect { job.perform_now }.to raise_error(IOError, 'no content found for :original_file')
+    end
   end
 end


### PR DESCRIPTION
Fixes #792 

CharacterizationJob needs the file instead of the file set. Use the proxy that's defined as `characterization_proxy` on the file set, which by default is `:original_file`

@projecthydra/sufia-code-reviewers

