### PR TITLE
Changing media display to use solr document instead of pulling the fille set from fedora

### DIFF
--- a/app/helpers/curation_concerns/file_set_helper.rb
+++ b/app/helpers/curation_concerns/file_set_helper.rb
@@ -7,9 +7,12 @@ module CurationConcerns::FileSetHelper
     end
   end
 
-  def media_display(file_set, locals = {})
-    render media_display_partial(file_set),
-           locals.merge(file_set: file_set)
+  # REVIEW: Since this media display could theoretically work for
+  #         any object that inplements to_s and the Mime Type methos (image? audio? ...),
+  #         Should this really be in file_set or could it be in it's own helper class like media_helper?
+  def media_display(presenter, locals = {})
+    render media_display_partial(presenter),
+           locals.merge(file_set: presenter)
   end
 
   def media_display_partial(file_set)

--- a/app/presenters/curation_concerns/work_show_presenter.rb
+++ b/app/presenters/curation_concerns/work_show_presenter.rb
@@ -40,6 +40,12 @@ module CurationConcerns
       @file_set_presenters ||= member_presenters(ordered_ids & file_set_ids)
     end
 
+    # @return FileSetPresenter presenter for the representative FileSets
+    def representative_presenter
+      return nil if representative_id.blank?
+      @representative_presenter ||= member_presenters([representative_id]).first
+    end
+
     # @return [Array<WorkShowPresenter>] presenters for the ordered_members that are not FileSets
     def work_presenters
       @work_presenters ||= member_presenters(ordered_ids - file_set_ids, work_presenter_class)

--- a/app/views/curation_concerns/base/_representative_media.html.erb
+++ b/app/views/curation_concerns/base/_representative_media.html.erb
@@ -1,5 +1,5 @@
-<% if presenter.representative_id.present? && (fs = ::FileSet.find(presenter.representative_id)) %>
-  <%= media_display fs %>
+<% if presenter.representative_id.present? %>
+  <%= media_display presenter.representative_presenter %>
 <% else %>
   <%= image_tag 'nope.png', class: "canonical-image" %>
 <% end %>

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -23,6 +23,13 @@ FactoryGirl.define do
       end
     end
 
+    factory :work_with_representative_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'])
+        work.representative_id = work.members[0].id
+      end
+    end
+
     factory :work_with_file_and_work do
       before(:create) do |work, evaluator|
         work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user)

--- a/spec/presenters/curation_concerns/work_show_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/work_show_presenter_spec.rb
@@ -109,6 +109,20 @@ describe CurationConcerns::WorkShowPresenter do
     end
   end
 
+  describe "#representative_presenter" do
+    let(:obj) { create(:work_with_representative_file) }
+    let(:attributes) { obj.to_solr }
+    let(:presenter_class) { double }
+    before do
+      allow(presenter).to receive(:file_presenter_class).and_return(presenter_class)
+    end
+    it "has a representative" do
+      expect(CurationConcerns::PresenterFactory).to receive(:build_presenters)
+        .with([obj.members[0].id], presenter_class, ability).and_return ["abc"]
+      expect(presenter.representative_presenter).to eq("abc")
+    end
+  end
+
   describe "#collection_presenters" do
     let(:collection) { create(:collection) }
     let(:obj) { create(:work) }


### PR DESCRIPTION
Fixes #785 

Using SolrDocument which includes the mime types and the representative ID to display the media instead on using the fedora files set.

Changes proposed in this pull request:
* Use presenter and solr document instead of fedora file set


@projecthydra/sufia-code-reviewers