### PR TITLE
Generated code runs afoul of Rubocop.

### DIFF
--- a/lib/generators/curation_concerns/work/templates/actor.rb.erb
+++ b/lib/generators/curation_concerns/work/templates/actor.rb.erb
@@ -1,6 +1,8 @@
 # Generated via
 #  `rails generate curation_concerns:work <%= class_name %>`
-module CurationConcerns::Actors
-  class <%= class_name %>Actor < CurationConcerns::Actors::BaseActor
+module CurationConcerns
+  module Actors
+    class <%= class_name %>Actor < CurationConcerns::Actors::BaseActor
+    end
   end
 end

--- a/lib/generators/curation_concerns/work/templates/controller.rb.erb
+++ b/lib/generators/curation_concerns/work/templates/controller.rb.erb
@@ -1,7 +1,9 @@
 # Generated via
 #  `rails generate curation_concerns:work <%= class_name %>`
 
-class CurationConcerns::<%= class_name.pluralize %>Controller < ApplicationController
-  include CurationConcerns::CurationConcernController
-  self.curation_concern_type = <%= class_name %>
+module CurationConcerns
+  class <%= class_name.pluralize %>Controller < ApplicationController
+    include CurationConcerns::CurationConcernController
+    self.curation_concern_type = <%= class_name %>
+  end
 end


### PR DESCRIPTION
The Actor and Controller generated by the work generator violate the `Style/ClassAndModuleChildren` rule that is enabled by default in Rubocop.