### PR TITLE
Add :keyword delegate to CurationConcerns::CollectionPresenter

### DIFF
--- a/app/presenters/curation_concerns/collection_presenter.rb
+++ b/app/presenters/curation_concerns/collection_presenter.rb
@@ -17,7 +17,7 @@ module CurationConcerns
              :to_s, to: :solr_document
 
     # Metadata Methods
-    delegate :title, :description, :creator, :contributor, :subject, :publisher, :language,
+    delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,
              :embargo_release_date, :lease_expiration_date, :rights, :date_created, to: :solr_document
 
     def size

--- a/spec/presenters/curation_concerns/collection_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/collection_presenter_spec.rb
@@ -6,6 +6,7 @@ describe CurationConcerns::CollectionPresenter do
           id: 'adc12v',
           description: ['a nice collection'],
           title: ['A clever title'],
+          keyword: ['neologism'],
           date_created: ['some date'])
   end
   let(:work) { build(:work, title: ['unimaginitive title']) }
@@ -19,6 +20,11 @@ describe CurationConcerns::CollectionPresenter do
   describe '#title' do
     subject { presenter.title }
     it { is_expected.to eq ['A clever title'] }
+  end
+
+  describe '#keyword' do
+    subject { presenter.keyword }
+    it { is_expected.to eq ['neologism'] }
   end
 
   describe '#to_key' do


### PR DESCRIPTION
Fixes [Sufia #2033](https://github.com/projecthydra/sufia/issues/2033)

Sufia expects keyword delegation from CurationConcerns::CollectionPresenter. Currently, adding a keyword in Sufia's new collection form returns the error: undefined method keyword for Sufia::CollectionPresenter. The SolrDocument already contains keyword, so adding the keyword delegation should solve this issue.

Changes proposed in this pull request:
* add keyword delegation to CurationConcerns::CollectionPresenter

@projecthydra/sufia-code-reviewers

